### PR TITLE
Removed indexing from downsampling process.

### DIFF
--- a/django/bossspatialdb/views.py
+++ b/django/bossspatialdb/views.py
@@ -31,6 +31,7 @@ from bosscore.models import Channel
 from spdb.spatialdb.spatialdb import SpatialDB, CUBOIDSIZE
 from spdb import project
 import bossutils
+from bossutils.aws import get_region
 
 
 class Cutout(APIView):
@@ -373,7 +374,6 @@ class Downsample(APIView):
 
             's3_bucket': boss_config["aws"]["cuboid_bucket"],
             's3_index': boss_config["aws"]["s3-index-table"],
-            'id_index': boss_config["aws"]["id-index-table"],
 
             'x_start': int(coord_frame.x_start),
             'y_start': int(coord_frame.y_start),
@@ -387,14 +387,13 @@ class Downsample(APIView):
             'resolution_max': int(experiment.num_hierarchy_levels),
             'res_lt_max': int(channel.base_resolution) + 1 < int(experiment.num_hierarchy_levels),
 
-            # DP NOTE: hardcode for the moment, users will expect not all resolutions will be indexed
-            'annotation_index_max': 1,  # Set to 1 to avoid resolutions on other downsampling levels other then 0.
-                                        # (Resolution 0 should already exist)
-
             'type': experiment.hierarchy_method,
             'iso_resolution': int(resource.get_isotropic_level()),
 
+            # This step function executes: boss-tools/activities/resolution_hierarchy.py
             'downsample_volume_sfn': boss_config['sfn']['downsample_volume_sfn'],
+
+            'aws_region': get_region()
         }
 
         session = bossutils.aws.get_session()


### PR DESCRIPTION
**Note:** merging this into the id-index-update branch. Made a separate PR for this to make it easier to see what the changes are to the downsampling code.

May not always want to index a downsampled channel.  Also, indexing
process is much more complex so decoupling so downsampling isn't
potentially broken by indexing.

Add aws-region argument.

Just in case we end up running in another region.
Remove id_index argument since indexing is now decoupled from
downsampling.

### Related PRs:
* https://github.com/jhuapl-boss/boss-manage/pull/9
* https://github.com/jhuapl-boss/boss-tools/pull/5