### PR TITLE
Verification of ingest job before complete allowed.

### DIFF
--- a/django/bossingest/ingest_manager.py
+++ b/django/bossingest/ingest_manager.py
@@ -24,6 +24,7 @@ from ingestclient.core.backend import BossBackend
 
 from bossingest.serializers import IngestJobCreateSerializer, IngestJobListSerializer
 from bossingest.models import IngestJob
+from bossingest.utils import query_tile_index, patch_upload_queue
 
 from bosscore.error import BossError, ErrorCodes, BossResourceNotFoundError
 from bosscore.models import Collection, Experiment, Channel
@@ -43,6 +44,7 @@ from bossutils.ingestcreds import IngestCredentials
 config = bossutils.configuration.BossConfig()
 INGEST_BUCKET = config["aws"]["ingest_bucket"]
 INGEST_LAMBDA = config["lambda"]["ingest_function"]
+TILE_INDEX = config["aws"]["tile-index-table"]
 
 CONNECTER = '&'
 MAX_NUM_MSG_PER_FILE = 10000
@@ -287,6 +289,28 @@ class IngestManager:
         queue = IngestQueue(self.nd_proj, endpoint_url=None)
         return queue
 
+    def verify_ingest_job(self, ingest_job):
+        """
+        Verify that all tiles ingested successfully
+        Args:
+            ingest_job (IngestJob):
+
+        Returns:
+            (bool): True == verified
+        """
+        try:
+            csv_file = query_tile_index(ingest_job.id, TILE_INDEX, bossutils.aws.get_region())
+            if csv_file is not None:
+                upload_queue = self.get_ingest_job_upload_queue(ingest_job)
+                args = self._generate_upload_queue_args(ingest_job)
+                patch_upload_queue(upload_queue.queue, args, csv_file)
+                return False
+
+            # success
+            return True
+        except Exception as e:
+            raise BossError("Unable to verify ingest job: {}".format(e), ErrorCodes.BOSS_SYSTEM_ERROR)
+
     def cleanup_ingest_job(self, ingest_job, job_status):
         """
         Delete or complete an ingest job with a specific id. Note this deletes the queues, credentials and all the remaining tiles
@@ -395,17 +419,32 @@ class IngestManager:
             raise BossError("Unable to generate upload tasks for the ingest service. Please specify a ingest job",
                             ErrorCodes.UNABLE_TO_VALIDATE)
 
-        ingest_job = self.job
+        args = self._generate_upload_queue_args(self.job)
+        args['upload_sfn'] = config['sfn']['upload_sfn']
+
+        session = bossutils.aws.get_session()
+        populate_sfn = config['sfn']['populate_upload_queue']
+        arn = bossutils.aws.sfn_execute(session, populate_sfn, args)
+
+        return arn
+
+    def _generate_upload_queue_args(self, ingest_job):
+        """
+        Generate dictionary to include in messages placed in the tile upload queue.
+        
+        Args:
+            ()
+
+        Returns:
+            (dict)
+        """
 
         bosskey = ingest_job.collection + CONNECTER + ingest_job.experiment + CONNECTER + ingest_job.channel
         lookup_key = (LookUpKey.get_lookup_key(bosskey)).lookup_key
         [col_id, exp_id, ch_id] = lookup_key.split('&')
         project_info = [col_id, exp_id, ch_id]
 
-        # TODO DP ???: create IngestJob method that creates the StepFunction arguments?
         args = {
-            'upload_sfn': config['sfn']['upload_sfn'],
-
             'job_id': ingest_job.id,
             'upload_queue': ingest_job.upload_queue,
             'ingest_queue': ingest_job.ingest_queue,
@@ -429,14 +468,10 @@ class IngestManager:
             'z_stop': ingest_job.z_stop,
             'z_tile_size': 1,
 
-
+            'z_chunk_size': 16
         }
 
-        session = bossutils.aws.get_session()
-        populate_sfn = config['sfn']['populate_upload_queue']
-        arn = bossutils.aws.sfn_execute(session, populate_sfn, args)
-
-        return arn
+        return args
 
     def generate_upload_tasks(self, job_id=None):
         """

--- a/django/bossingest/models.py
+++ b/django/bossingest/models.py
@@ -23,12 +23,20 @@ class IngestJob(models.Model):
     creator = models.ForeignKey(settings.AUTH_USER_MODEL)
     start_date = models.DateTimeField(auto_now_add=True)
     end_date = models.DateTimeField(null=True)
+
+    # Ingest status constants.
+    PREPARING = 0
+    UPLOADING = 1
+    COMPLETE = 2
+    DELETED = 3
+    FAILED = 4
+
     INGEST_STATUS_OPTIONS = (
-            (0, 'Preparing'),
-            (1, 'Uploading'),
-            (2, 'Complete'),
-            (3, 'Deleted'),
-            (4, 'Failed'),
+            (PREPARING, 'Preparing'),
+            (UPLOADING, 'Uploading'),
+            (COMPLETE, 'Complete'),
+            (DELETED, 'Deleted'),
+            (FAILED, 'Failed')
         )
     status = models.IntegerField(choices=INGEST_STATUS_OPTIONS, default=0)
     upload_queue = models.URLField(max_length=512, null=True)

--- a/django/bossingest/test/int_test_ingest_views.py
+++ b/django/bossingest/test/int_test_ingest_views.py
@@ -24,14 +24,44 @@ from django.conf import settings
 from bosscore.test.setup_db import SetupTestDB
 from bossingest.test.setup import SetupTests
 from bossingest.ingest_manager import IngestManager
+from bossingest.models import IngestJob
 from botocore.exceptions import ClientError
 
+from contextlib import contextmanager
+
+from ndingest.nddynamo.boss_tileindexdb import BossTileIndexDB
 from ndingest.ndqueue.ndqueue import NDQueue
 from ndingest.ndqueue.uploadqueue import UploadQueue
 from ndingest.ndqueue.ingestqueue import IngestQueue
 from ndingest.ndingestproj.bossingestproj import BossIngestProj
 
+from random import randint;
+
 version = settings.BOSS_VERSION
+
+@contextmanager
+def add_tile_entry(ingest_job):
+    """
+    Put a fake chunk in the tile index for the given job.  Cleans up fake chunk
+    when it goes out of scope.
+
+    Args:
+        ingest_job (dict): Job data as returned by the POST method.
+
+    Yields:
+        (None)
+    """
+    tiledb = BossTileIndexDB(ingest_job['collection'] + '&' + ingest_job['experiment'])
+    chunk_key = '{}&16&1&2&3&0&0&0&0&0'.format(randint(0, 2000))
+    tiledb.createCuboidEntry(chunk_key, ingest_job['id'])
+    # Mark some tiles as uploaded.
+    for i in range(12):
+        tiledb.markTileAsUploaded(chunk_key, 'fake_tile_key_{}'.format(i), ingest_job['id'])
+    yield
+
+    # Cleanup.
+    print('deleting fake chunk')
+    tiledb.deleteCuboid(chunk_key, ingest_job['id'])
 
 
 class BossIngestViewTestMixin(object):
@@ -57,7 +87,7 @@ class BossIngestViewTestMixin(object):
         # # Post the data
         url = '/' + version + '/ingest/'
         response = self.client.post(url, data=config_data, format='json')
-        assert (response.status_code == 201)
+        self.assertEqual(201, response.status_code)
 
         # Check if the queue's exist
         ingest_job = response.json()
@@ -66,20 +96,20 @@ class BossIngestViewTestMixin(object):
                              0, ingest_job['id'])
         self.nd_proj = nd_proj
         upload_queue = UploadQueue(nd_proj, endpoint_url=None)
-        assert (upload_queue is not None)
+        self.assertIsNotNone(upload_queue)
         ingest_queue = IngestQueue(nd_proj, endpoint_url=None)
-        assert (ingest_queue is not None)
+        self.assertIsNotNone(ingest_queue)
 
         # Test joining the job
         url = '/' + version + '/ingest/{}/'.format(ingest_job['id'])
         response = self.client.get(url)
-        assert (response.json()['ingest_job']['id'] == ingest_job['id'])
-        assert("credentials" in response.json())
+        self.assertEqual(response.json()['ingest_job']['id'], ingest_job['id'])
+        self.assertIn("credentials", response.json())
 
         # # Delete the job
         url = '/' + version + '/ingest/{}/'.format(ingest_job['id'])
         response = self.client.delete(url)
-        assert (response.status_code == 204)
+        self.assertEqual(204, response.status_code)
 
         # Verify Queues are removed
         with self.assertRaises(ClientError):
@@ -101,19 +131,19 @@ class BossIngestViewTestMixin(object):
         self.client.force_login(self.superuser)
         url = '/' + version + '/ingest/'
         response = self.client.post(url, data=config_data, format='json')
-        assert (response.status_code == 201)
+        self.assertEqual(201, response.status_code)
         ingest_job = response.json()
 
         # Log in as the user and try to join but fail
         self.client.force_login(self.user)
         url = '/' + version + '/ingest/{}/'.format(ingest_job['id'])
         response = self.client.get(url)
-        assert (response.status_code == 403)
+        self.assertEqual(403, response.status_code)
 
         # # Delete the job
         url = '/' + version + '/ingest/{}/'.format(ingest_job['id'])
         response = self.client.delete(url)
-        assert (response.status_code == 403)
+        self.assertEqual(403, response.status_code)
 
     def test_not_creator_admin(self):
         """Method to test only creators or admins can interact with ingest jobs"""
@@ -123,7 +153,7 @@ class BossIngestViewTestMixin(object):
         # # Post the data
         url = '/' + version + '/ingest/'
         response = self.client.post(url, data=config_data, format='json')
-        assert (response.status_code == 201)
+        self.assertEqual(201, response.status_code)
 
         # Check if the queue's exist
         ingest_job = response.json()
@@ -132,9 +162,9 @@ class BossIngestViewTestMixin(object):
                              0, ingest_job['id'])
         self.nd_proj = nd_proj
         upload_queue = UploadQueue(nd_proj, endpoint_url=None)
-        assert (upload_queue is not None)
+        self.assertIsNotNone(upload_queue)
         ingest_queue = IngestQueue(nd_proj, endpoint_url=None)
-        assert (ingest_queue is not None)
+        self.assertIsNotNone(ingest_queue)
 
         # Log in as the admin and create a job
         self.client.force_login(self.superuser)
@@ -142,14 +172,14 @@ class BossIngestViewTestMixin(object):
         # Test joining the job
         url = '/' + version + '/ingest/{}/'.format(ingest_job['id'])
         response = self.client.get(url)
-        assert (response.status_code == 200)
-        assert (response.json()['ingest_job']['id'] == ingest_job['id'])
-        assert("credentials" in response.json())
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(response.json()['ingest_job']['id'], ingest_job['id'])
+        self.assertIn("credentials", response.json())
 
         # # Delete the job
         url = '/' + version + '/ingest/{}/'.format(ingest_job['id'])
         response = self.client.delete(url)
-        assert (response.status_code == 204)
+        self.assertEqual(204, response.status_code)
 
     def test_list_user_jobs(self):
         """ Test view to create a new ingest job """
@@ -160,14 +190,14 @@ class BossIngestViewTestMixin(object):
         # Post the data
         url = '/' + version + '/ingest/'
         response = self.client.post(url, data=config_data, format='json')
-        assert (response.status_code == 201)
+        self.assertEqual(201, response.status_code)
 
         # Check if the queue's exist
         ingest_job_1 = response.json()
 
         url = '/' + version + '/ingest/'
         response = self.client.post(url, data=config_data, format='json')
-        assert (response.status_code == 201)
+        self.assertEqual(201, response.status_code)
 
         # Check if the queue's exist
         ingest_job_2 = response.json()
@@ -175,12 +205,12 @@ class BossIngestViewTestMixin(object):
         # Delete the job 1
         url = '/' + version + '/ingest/{}/'.format(ingest_job_1['id'])
         response = self.client.delete(url)
-        assert (response.status_code == 204)
+        self.assertEqual(204, response.status_code)
 
         # Add another job
         url = '/' + version + '/ingest/'
         response = self.client.post(url, data=config_data, format='json')
-        assert (response.status_code == 201)
+        self.assertEqual(201, response.status_code)
         ingest_job_3 = response.json()
 
         # List
@@ -201,14 +231,14 @@ class BossIngestViewTestMixin(object):
         # Post the data
         url = '/' + version + '/ingest/'
         response = self.client.post(url, data=config_data, format='json')
-        assert (response.status_code == 201)
+        self.assertEqual(201, response.status_code)
 
         # Check if the queue's exist
         ingest_job_1 = response.json()
 
         url = '/' + version + '/ingest/'
         response = self.client.post(url, data=config_data, format='json')
-        assert (response.status_code == 201)
+        self.assertEqual(201, response.status_code)
 
         # Check if the queue's exist
         ingest_job_2 = response.json()
@@ -216,19 +246,15 @@ class BossIngestViewTestMixin(object):
         # Delete the job 1
         url = '/' + version + '/ingest/{}/'.format(ingest_job_1['id'])
         response = self.client.delete(url)
-        assert (response.status_code == 204)
+        self.assertEqual(204, response.status_code)
 
-        # Add a completed job
+        # Add a job that will be completed
         url = '/' + version + '/ingest/'
         response = self.client.post(url, data=config_data, format='json')
         assert (response.status_code == 201)
         ingest_job_completed = response.json()
-        url = '/' + version + '/ingest/{}/complete'.format(ingest_job_completed['id'])
-        response = self.client.post(url)
-        # Can't complete until it is done
-        assert(response.status_code == 400)
 
-        # Wait for job to complete
+        # Wait for job to "complete"
         for cnt in range(0, 30):
             # Try joining to kick the status
             url = '/' + version + '/ingest/{}/'.format(ingest_job_completed['id'])
@@ -236,7 +262,7 @@ class BossIngestViewTestMixin(object):
 
             url = '/' + version + '/ingest/{}/status'.format(ingest_job_completed['id'])
             response = self.client.get(url)
-            if response.json()["status"] == 1:
+            if response.json()["status"] == IngestJob.UPLOADING:
                 break
 
             time.sleep(10)
@@ -244,13 +270,13 @@ class BossIngestViewTestMixin(object):
         # Complete the job
         url = '/' + version + '/ingest/{}/complete'.format(ingest_job_completed['id'])
         response = self.client.post(url)
-        assert(response.status_code == 204)
+        self.assertEqual(204, response.status_code)
 
         # Log in as the admin and create a job
         self.client.force_login(self.superuser)
         url = '/' + version + '/ingest/'
         response = self.client.post(url, data=config_data, format='json')
-        assert (response.status_code == 201)
+        self.assertEqual(201, response.status_code)
 
         # Check if the queue's exist
         admin_ingest_job = response.json()
@@ -261,11 +287,11 @@ class BossIngestViewTestMixin(object):
         result = response.json()
         self.assertEqual(3, len(result["ingest_jobs"]))
         self.assertEqual(result["ingest_jobs"][0]['id'], ingest_job_2['id'])
-        self.assertEqual(result["ingest_jobs"][0]['status'], 0)
+        self.assertEqual(result["ingest_jobs"][0]['status'], IngestJob.PREPARING)
         self.assertEqual(result["ingest_jobs"][1]['id'], ingest_job_completed['id'])
-        self.assertEqual(result["ingest_jobs"][1]['status'], 2)
+        self.assertEqual(result["ingest_jobs"][1]['status'], IngestJob.COMPLETE)
         self.assertEqual(result["ingest_jobs"][2]['id'], admin_ingest_job['id'])
-        self.assertEqual(result["ingest_jobs"][2]['status'], 0)
+        self.assertEqual(result["ingest_jobs"][2]['status'], IngestJob.PREPARING)
 
     def test_complete_ingest_job(self):
         """ Test view to create a new ingest job """
@@ -275,33 +301,34 @@ class BossIngestViewTestMixin(object):
         # # Post the data
         url = '/' + version + '/ingest/'
         response = self.client.post(url, data=config_data, format='json')
-        assert (response.status_code == 201)
+        self.assertEqual(response.status_code, 201)
 
-        # Check if the queue's exist
+        # Check if the queues exist
         ingest_job = response.json()
         proj_class = BossIngestProj.load()
         nd_proj = proj_class(ingest_job['collection'], ingest_job['experiment'], ingest_job['channel'],
                              0, ingest_job['id'])
         self.nd_proj = nd_proj
         upload_queue = UploadQueue(nd_proj, endpoint_url=None)
-        assert (upload_queue is not None)
+        self.assertIsNotNone(upload_queue)
         ingest_queue = IngestQueue(nd_proj, endpoint_url=None)
-        assert (ingest_queue is not None)
+        self.assertIsNotNone(ingest_queue)
 
         # Test joining the job
         url = '/' + version + '/ingest/{}/'.format(ingest_job['id'])
         response = self.client.get(url)
-        assert(response.json()['ingest_job']['id'] == ingest_job['id'])
-        assert("credentials" in response.json())
+        self.assertEqual(response.json()['ingest_job']['id'], ingest_job['id'])
+        self.assertIn("credentials", response.json())
 
         # Complete the job
         url = '/' + version + '/ingest/{}/complete'.format(ingest_job['id'])
         response = self.client.post(url)
 
         # Can't complete until it is done
-        assert(response.status_code == 400)
+        self.assertEqual(400, response.status_code)
 
         # Wait for job to complete
+        print('trying to join job')
         for cnt in range(0, 30):
             # Try joining to kick the status
             url = '/' + version + '/ingest/{}/'.format(ingest_job['id'])
@@ -309,15 +336,16 @@ class BossIngestViewTestMixin(object):
 
             url = '/' + version + '/ingest/{}/status'.format(ingest_job['id'])
             response = self.client.get(url)
-            if response.json()["status"] == 1:
+            if response.json()["status"] == IngestJob.UPLOADING:
                 break
 
             time.sleep(10)
 
+        print('completing')
         # Complete the job
         url = '/' + version + '/ingest/{}/complete'.format(ingest_job['id'])
         response = self.client.post(url)
-        assert(response.status_code == 204)
+        self.assertEqual(204, response.status_code)
 
         # Verify Queues are removed
         with self.assertRaises(ClientError):
@@ -328,8 +356,58 @@ class BossIngestViewTestMixin(object):
         # Verify status has changed
         url = '/' + version + '/ingest/{}/status'.format(ingest_job['id'])
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(200, response.status_code)
         self.assertEqual(response.json()["status"], 2)
+
+    def test_verify_ingest_job_not_done(self):
+        """ Test view to create a new ingest job """
+        config_data = self.setup_helper.get_ingest_config_data_dict()
+        config_data = json.loads(json.dumps(config_data))
+
+        # # Post the data
+        url = '/' + version + '/ingest/'
+        response = self.client.post(url, data=config_data, format='json')
+        self.assertEqual(response.status_code, 201)
+
+        # Check if the queue's exist
+        ingest_job = response.json()
+        proj_class = BossIngestProj.load()
+        nd_proj = proj_class(ingest_job['collection'], ingest_job['experiment'], ingest_job['channel'],
+                             0, ingest_job['id'])
+        self.nd_proj = nd_proj
+        upload_queue = UploadQueue(nd_proj, endpoint_url=None)
+        self.assertIsNotNone(upload_queue)
+        ingest_queue = IngestQueue(nd_proj, endpoint_url=None)
+        self.assertIsNotNone(ingest_queue)
+
+        # Test joining the job
+        url = '/' + version + '/ingest/{}/'.format(ingest_job['id'])
+        response = self.client.get(url)
+        self.assertEqual(response.json()['ingest_job']['id'], ingest_job['id'])
+        self.assertIn("credentials", response.json())
+
+        # Wait for job to complete
+        print('trying to join job')
+        for cnt in range(0, 30):
+            # Try joining to kick the status
+            url = '/' + version + '/ingest/{}/'.format(ingest_job['id'])
+            self.client.get(url)
+
+            url = '/' + version + '/ingest/{}/status'.format(ingest_job['id'])
+            response = self.client.get(url)
+            if response.json()["status"] == IngestJob.UPLOADING:
+                break
+
+            time.sleep(10)
+
+        print('faking ingest')
+        # Leave one chunk in the index to fake not being done.
+        with add_tile_entry(ingest_job):
+            print('trying to complete')
+            url = '/' + version + '/ingest/{}/complete'.format(ingest_job['id'])
+            response = self.client.post(url)
+            # Still have chunks in tile index
+            self.assertEqual(202, response.status_code)
 
     def test_job_status(self):
         """ Test status, waiting for a queue to actually populate """
@@ -355,7 +433,7 @@ class BossIngestViewTestMixin(object):
 
             url = '/' + version + '/ingest/{}/status'.format(ingest_job['id'])
             response = self.client.get(url)
-            if response.json()["status"] == 1:
+            if response.json()["status"] == IngestJob.UPLOADING:
                 break
 
             time.sleep(10)

--- a/django/bossingest/test/test_urls.py
+++ b/django/bossingest/test/test_urls.py
@@ -15,7 +15,7 @@
 from rest_framework.test import APITestCase
 from django.core.urlresolvers import resolve
 from django.conf import settings
-from bossingest.views import IngestJobView, IngestJobStatusView
+from bossingest.views import IngestJobView, IngestJobStatusView, IngestJobCompleteView
 
 version = settings.BOSS_VERSION
 
@@ -48,5 +48,15 @@ class BossIngestServiceRoutingTests(APITestCase):
         """
         match = resolve('/' + version + '/ingest/1/status')
         self.assertEqual(match.func.__name__, IngestJobStatusView.as_view().__name__)
+
+
+    def test_ingest_urls_with_id_status_resolves_to_BossIngestComplete_views(self):
+        """
+        Test that the ingest complete url resolves to the ingest complete view
+
+        Returns: None
+        """
+        match = resolve('/' + version + '/ingest/1/complete')
+        self.assertEqual(match.func.__name__, IngestJobCompleteView.as_view().__name__)
 
 

--- a/django/bossingest/test/test_utils.py
+++ b/django/bossingest/test/test_utils.py
@@ -1,0 +1,150 @@
+from bossingest.utils import query_tile_index, _query_tile_index, _create_messages
+from ingestclient.core.backend import BossBackend
+import json
+import os
+from tempfile import NamedTemporaryFile
+import unittest
+from unittest.mock import patch
+
+def fake_query_nonempty_data(job_id):
+    return [
+        {'Items': [
+            {
+                'chunk_key': {'S': 'some_chunk_key' },
+                'task_id': {'N': job_id},
+                'tile_uploaded_map': { 'M': {
+                    'fakekey1': 1,
+                    'fakekey2': 1,
+                    'fakekey3': 1,
+                    'fakekey4': 1,
+                    'fakekey5': 1,
+                    'fakekey6': 1,
+                    'fakekey7': 1,
+                    'fakekey8': 1,
+                    'fakekey9': 1,
+                    'fakekey10': 1,
+                    'fakekey11': 1,
+                    'fakekey12': 1,
+                    'fakekey13': 1,
+                    'fakekey14': 1,
+                    'fakekey15': 1,
+                    'fakekey16': 1
+                } }
+            },
+            {
+                'chunk_key': {'S': 'some_chunk_key2' },
+                'task_id': {'N': job_id},
+                'tile_uploaded_map': { 'M': {
+                    'fakekey21': 1,
+                    'fakekey22': 1,
+                    'fakekey23': 1,
+                    'fakekey24': 1,
+                    'fakekey25': 1,
+                    'fakekey26': 1,
+                    'fakekey27': 1,
+                    'fakekey28': 1,
+                    'fakekey29': 1,
+                    'fakekey30': 1,
+                    'fakekey31': 1,
+                    'fakekey32': 1,
+                    'fakekey33': 1,
+                    'fakekey34': 1,
+                    'fakekey35': 1,
+                    'fakekey36': 1
+                } } 
+            }
+        ]}
+    ]
+
+def fake_query_tile_ind_side_effects(paginator, tile_index_name, job_id, i):
+    if i != 20:
+        return []
+
+    return fake_query_nonempty_data(job_id)
+
+
+class TestUtils(unittest.TestCase):
+
+    @patch('bossingest.utils._query_tile_index', return_value=[])
+    def test_query_tile_index_no_chunks(self, fake_query_tile_ind):
+        job_id = 4
+        tile_index_name = 'tiles.test.boss'
+        region = 'us-east-1'
+        self.assertIsNone(query_tile_index(job_id, tile_index_name, region))
+
+    @patch('bossingest.utils._query_tile_index', side_effect=fake_query_tile_ind_side_effects)
+    def test_query_tile_index(self, fake_query_tile_ind):
+        job_id = 4
+        tile_index_name = 'tiles.test.boss'
+        region = 'us-east-1'
+        csv_file = query_tile_index(job_id, tile_index_name, region)
+        expected = fake_query_nonempty_data(job_id)
+
+        try:
+            with open(csv_file, 'rt') as csv_in:
+                lines = csv_in.readlines()
+                for i, line in enumerate(lines):
+                    columns = line.strip().split(',')
+                    if i < 2:
+                        exp = expected[0]['Items'][i]
+                        self.assertEqual(exp['chunk_key']['S'], columns[0])
+                        self.assertEqual(exp['task_id']['N'], int(columns[1]))
+                        self.assertEqual(len(exp['tile_uploaded_map']['M']), int(columns[2]))
+                    else:
+                        self.fail('Too many lines written')
+        finally:
+            os.remove(csv_file)
+
+    def test_create_messages(self):
+        job_id = 8
+        num_tiles = 16
+        exp_upload_queue = 'upload-test-queue'
+        exp_ingest_queue = 'ingest-test-queue'
+        args = {
+            'job_id': job_id,
+            'project_info': [5, 3, 2], # Collection/Experiment/Channel ids
+            'z_chunk_size': 16,
+            'resolution': 0,
+            'upload_queue': exp_upload_queue,
+            'ingest_queue': exp_ingest_queue
+        }
+
+        backend = BossBackend(None)
+        x1, y1, z1 = (0, 0, 0)
+        x2, y2, z2  = (1024, 1024, 16)
+        res = 0
+        t = 2
+        chunk_key1 = backend.encode_chunk_key(num_tiles, args['project_info'], res, x1, y1, z1, t) 
+        chunk_key2 = backend.encode_chunk_key(num_tiles, args['project_info'], res, x2, y2, z2, t)
+        with NamedTemporaryFile(
+            mode='wt',
+            suffix='.csv',
+            delete=False
+        ) as output_csv:
+            csv_file = output_csv.name
+            output_csv.write('{},{},{}'.format(chunk_key1, job_id, num_tiles))
+            output_csv.write('{},{},{}'.format(chunk_key2, job_id, num_tiles))
+
+        try:
+            actual = _create_messages(args, csv_file)
+            for i, raw_msg in enumerate(actual):
+                msg = json.loads(raw_msg)
+                self.assertEqual(job_id, msg['job_id'])
+                self.assertEqual(exp_upload_queue, msg['upload_queue_arn'])
+                self.assertEqual(exp_ingest_queue, msg['ingest_queue_arn'])
+                if i < 16:
+                    self.assertEqual(chunk_key1, msg['chunk_key'])
+                    exp_tile_key = backend.encode_tile_key(
+                        args['project_info'], res, x1, y1, z1 + i, t)
+                    self.assertEqual(exp_tile_key, msg['tile_key'])
+                elif i < 32:
+                    self.assertEqual(chunk_key2, msg['chunk_key'])
+                    exp_tile_key = backend.encode_tile_key(
+                        args['project_info'], res, x2, y2, z2 + i - 16, t)
+                    self.assertEqual(exp_tile_key, msg['tile_key'])
+                else:
+                    self.fail('Too many messages returned')
+
+        finally:
+            os.remove(csv_file)
+

--- a/django/bossingest/utils.py
+++ b/django/bossingest/utils.py
@@ -1,0 +1,183 @@
+from bosscore.error import BossError, ErrorCodes, BossResourceNotFoundError
+import boto3
+import json
+from ingestclient.core.backend import BossBackend
+from ndingest.nddynamo.boss_tileindexdb import BossTileIndexDB, MAX_TASK_ID_SUFFIX, TASK_INDEX
+from ndingest.ndingestproj.bossingestproj import BossIngestProj
+from ndingest.ndqueue.uploadqueue import UploadQueue
+import os
+from tempfile import NamedTemporaryFile
+
+# First value should be job id.
+CSV_FORMAT_STR = 'tiles-{}&'
+
+# SQS Hardlimit
+SQS_BATCH_SIZE = 10
+SQS_RETRY_TIMEOUT = 15
+
+def query_tile_index(job_id, tile_index_name, region):
+    """
+    Find all chunks belonging to a job and output those that have more than
+    10 tiles to a .csv file named by the job_id.
+
+    Args:
+        job_id (int): Id of ingest job.
+        tile_index_name (str): Name of DynamoDB tile index table.
+
+    Returns:
+        (str|None): Filename of list of chunks that meet criteria or None.
+    """
+    client = boto3.client('dynamodb', region_name=region)
+
+    paginator = client.get_paginator('query')
+    work_to_do = False
+
+    with NamedTemporaryFile(
+        mode='wt',
+        prefix=CSV_FORMAT_STR.format(job_id),
+        suffix='.csv',
+        delete=False
+    ) as output_csv:
+        output_file = output_csv.name
+        for i in range(MAX_TASK_ID_SUFFIX):
+            response_iterator = _query_tile_index(paginator, tile_index_name, job_id, i)
+
+            for response in response_iterator:
+                for item in response["Items"]:
+                    if len(item["tile_uploaded_map"]["M"]) > 10:
+                        # If more than 10 tiles were uploaded we'll assume it's a missing block and reupload it
+                        record = "{},{},{}\n".format(
+                            item["chunk_key"]["S"], item["task_id"]["N"],
+                            len(item["tile_uploaded_map"]["M"]))
+                        output_csv.write(record)
+                        work_to_do = True
+
+    if not work_to_do:
+        os.remove(output_file)
+        return None
+
+    return output_file
+
+def _query_tile_index(paginator, tile_index_name, job_id, i):
+    """
+    Query tile index table for chunks with the given job_id and suffix.
+
+    Args:
+        paginator (boto3.Paginator):
+        tile_index_name (str): Name of DynamoDB tile index table.
+        job_id (int): Id of ingest job.
+        i (int): Suffix for job_id (which Dynamo partition to check).
+
+    Returns:
+        (list[response])
+    """
+    return paginator.paginate(
+        TableName=tile_index_name, 
+        IndexName=TASK_INDEX,
+        KeyConditionExpression="appended_task_id = :task_id_val",
+        ExpressionAttributeValues={
+            ":task_id_val": {
+                "S": BossTileIndexDB.generate_appended_task_id(job_id, i)
+            }
+        }
+    )
+
+def patch_upload_queue(upload_queue, msg_args, csv_file):
+    """
+    Populate the upload queue with tile info.
+
+    Args:
+        upload_queue (SQS.Queue): Tile upload queue.
+        msg_args (dict): Arguments to put in queue message.
+        csv_file (str): Name of csv file with tile info.
+    """
+
+    msgs = _create_messages(msg_args, csv_file)
+    sent = 0
+
+    # Implement a custom queue.sendBatchMessages so that more than 10
+    # messages can be sent at once (hard limit in sendBatchMessages)
+    while True:
+        batch = []
+        for i in range(SQS_BATCH_SIZE):
+            try:
+                batch.append({
+                    'Id': str(i),
+                    'MessageBody': next(msgs),
+                    'DelaySeconds': 0
+                })
+            except StopIteration:
+                break
+
+        if len(batch) == 0:
+            break
+
+        retry = 3
+        while retry > 0:
+            resp = upload_queue.send_messages(Entries=batch)
+            sent += len(resp['Successful'])
+
+            if 'Failed' in resp and len(resp['Failed']) > 0:
+                time.sleep(SQS_RETRY_TIMEOUT)
+
+                ids = [f['Id'] for f in resp['Failed']]
+                batch = [b for b in batch if b['Id'] in ids]
+                retry -= 1
+                if retry == 0:
+                    raise BossError("Failed trying to repopulate tile queue")
+                continue
+            else:
+                break
+
+def _create_messages(args, index_csv):
+    """
+    Create all of the tile messages to be enqueued.
+
+    Args:
+        args (dict): Same arguments as patch_upload_queue().
+        index_csv (str): CSV file with tile info.
+
+    Generates:
+        (list): List of strings containing Json data
+    """
+
+    # DP NOTE: configuration is not actually used by encode_*_key method
+    backend = BossBackend(None)
+
+    chunk_key_list = []
+    with open(index_csv, "rt") as data:
+        lines = data.readlines()
+        for line in lines:
+            parts = line.split(",")
+            chunk_key_list.append(parts[0])
+
+    msgs = []
+    for base_chunk_key in chunk_key_list:
+        parts = backend.decode_chunk_key(base_chunk_key)
+        chunk_x = parts['x_index']
+        chunk_y = parts['y_index']
+        chunk_z = parts['z_index']
+        t = parts['t_index']
+
+        num_of_tiles = parts['num_tiles']
+
+        chunk_key = base_chunk_key
+        z_start = chunk_z * args['z_chunk_size']
+
+        for tile in range(z_start, z_start + num_of_tiles):
+            tile_key = backend.encode_tile_key(args['project_info'],
+                                               args['resolution'],
+                                               chunk_x,
+                                               chunk_y,
+                                               tile,
+                                               t)
+
+            msg = {
+                'job_id': args['job_id'],
+                'upload_queue_arn': args['upload_queue'],
+                'ingest_queue_arn': args['ingest_queue'],
+                'chunk_key': chunk_key,
+                'tile_key': tile_key,
+            }
+
+            yield json.dumps(msg)


### PR DESCRIPTION
Backend verifies that ingest job finished before actually "completing"
the job.  Backend returns status code 202 and adds tiles from incomplete
chunks back to the upload queue.

Related PRs:
https://github.com/jhuapl-boss/ndingest/pull/4
https://github.com/jhuapl-boss/ingest-client/pull/9