### PR TITLE
Bossadmin as maintainer of every group cannot be deleted - to integration

### DIFF
--- a/django/bosscore/test/test_group_views.py
+++ b/django/bosscore/test/test_group_views.py
@@ -537,7 +537,7 @@ class GroupMaintainerTests(APITestCase):
         # Attempt removal of bossadmin from the group
         url = '/' + version + '/groups/unittest/maintainers/bossadmin/'
         response = self.client.delete(url)
-        self.assertRaises(Exception)
+        self.assertEqual(response.status_code, 400)    
 
     def test_group_maintainer_invalid_group(self):
         """ Test group-maintainer api calls with a group that does not exist """

--- a/django/bosscore/test/test_group_views.py
+++ b/django/bosscore/test/test_group_views.py
@@ -145,7 +145,6 @@ class GroupsTests(APITestCase):
         response = self.client.delete(url)
         self.assertEqual(response.status_code, 204)
 
-
 class GroupMemberTests(APITestCase):
     """
     Class to test gropup member views
@@ -283,6 +282,25 @@ class GroupMemberTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['result'], False)
+
+    def test_remove_bossadmin_member_invalid(self):
+
+        # Add user to the group
+        url = '/' + version + '/groups/unittest/members/bossadmin/'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 204)
+
+        """ Remove bossadmin member from a group. This is invalid"""
+        # Check if user is a member of the group
+        url = '/' + version + '/groups/unittest/members/bossadmin/'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['result'], True)
+
+        # Remove user from the group
+        url = '/' + version + '/groups/unittest/members/bossadmin/'
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 400)
 
     def test_group_member_invalid_group(self):
         """ Test group-memeber api calls with a group that does not exist """
@@ -507,6 +525,20 @@ class GroupMaintainerTests(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn('testuser', response.data['maintainers'])
 
+    def test_remove_bossadmin_maintainer_group_fails(self):
+        """ Test removal of bossadmin as a maintainer of a group fails"""
+
+        # Check if bossadmin user is a member of the group
+        url = '/' + version + '/groups/unittest/maintainers/bossadmin/'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['result'], True)
+
+        # Attempt removal of bossadmin from the group
+        url = '/' + version + '/groups/unittest/maintainers/bossadmin/'
+        response = self.client.delete(url)
+        self.assertRaises(Exception)
+
     def test_group_maintainer_invalid_group(self):
         """ Test group-maintainer api calls with a group that does not exist """
 
@@ -599,4 +631,3 @@ class GroupMaintainerTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(set(response.data['maintainers']), set(['testuser']))
-

--- a/django/bosscore/views/views_group.py
+++ b/django/bosscore/views/views_group.py
@@ -238,7 +238,7 @@ class BossGroupMaintainer(APIView):
     @check_role("resource-manager")
     def delete(self, request, group_name, user_name):
         """
-        Removes a maintainer form the group
+        Removes a maintainer from the group
         Args:
             request: Django rest framework request
             group_name:Group name from the request
@@ -416,13 +416,16 @@ class BossUserGroup(APIView):
 
         """
         try:
-
             group = Group.objects.get(name=group_name)
             bgroup = BossGroup.objects.get(group=group)
             bpm = BossPrivilegeManager(request.user)
             if request.user == bgroup.creator or bpm.has_role('admin'):
-                group.delete()
-                return Response(status=204)
+                if group_name == 'admin' or group_name == 'public':
+                    return BossHTTPError('Admin and public groups cannot be deleted.',
+                                        ErrorCodes.ACCESS_DENIED_UNKNOWN)  
+                else:
+                    group.delete()
+                    return Response(status=204)
             else:
                 return BossHTTPError('Groups can only be deleted by the creator or administrator',
                                      ErrorCodes.MISSING_ROLE)

--- a/django/bosscore/views/views_group.py
+++ b/django/bosscore/views/views_group.py
@@ -129,6 +129,10 @@ class BossGroupMember(APIView):
             group = Group.objects.get(name=group_name)
             bgroup = BossGroup.objects.get(group=group)
 
+            if user_name == 'bossadmin':
+                return BossHTTPError('Cannot remove bossadmin from any group'
+                                     .format(group_name), ErrorCodes.BAD_REQUEST)
+
             # Check the users permissions.
             if request.user.has_perm("maintain_group", bgroup):
                 usr = User.objects.get(username=user_name)
@@ -254,6 +258,10 @@ class BossGroupMaintainer(APIView):
                                      .format(group_name), ErrorCodes.BAD_REQUEST)
             if user_name is None:
                 return BossHTTPError('Missing username parameter in post.', ErrorCodes.INVALID_URL)
+            
+            elif user_name == 'bossadmin':
+                return BossHTTPError('Cannot remove boassadmin maintainer from any group',
+                                     ErrorCodes.BAD_REQUEST)
 
             group = Group.objects.get(name=group_name)
             bgroup = BossGroup.objects.get(group=group)
@@ -422,7 +430,7 @@ class BossUserGroup(APIView):
             if request.user == bgroup.creator or bpm.has_role('admin'):
                 if group_name == 'admin' or group_name == 'public':
                     return BossHTTPError('Admin and public groups cannot be deleted.',
-                                        ErrorCodes.ACCESS_DENIED_UNKNOWN)  
+                                        ErrorCodes.BAD_REQUEST)  
                 else:
                     group.delete()
                     return Response(status=204)

--- a/django/sso/tests/test_users.py
+++ b/django/sso/tests/test_users.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from unittest import mock
+from sso.views.views_user import *
 import json
 
 from .test_base import TestBase, raise_error
@@ -123,6 +124,15 @@ class TestBossUser(TestBase):
 
         call = mock.call.delete_user('test')
         self.assertEqual(ctxMgr.mock_calls, [call])
+
+    @mock.patch('sso.views.views_user.KeyCloakClient', autospec = True)
+    def test_delete_user_bossadmin(self, mKCC):
+        ctxMgr = mKCC.return_value.__enter__.return_value
+
+        request = self.makeRequest(delete='/' + version + '/sso/user/bossadmin')
+        response = BossUser.as_view()(request, 'bossadmin')
+
+        self.assertEqual(response.status_code, 500)
 
     @mock.patch('sso.views.views_user.KeyCloakClient', autospec = True)
     def test_failed_delete_user(self, mKCC):

--- a/django/sso/views/views_user.py
+++ b/django/sso/views/views_user.py
@@ -163,23 +163,18 @@ class BossUser(APIView):
             None
         """
         # DP TODO: verify user_name is not an admin
-        bp = BossPrivilegeManager(user_name)
-        if bp.has_role('admin'):
-            return BossKeycloakError('The user is an admin')
+        if user_name == 'bossadmin':
+            msg = "Cannot delete user bossadmin from Keycloak".format(user_name)
+            return BossKeycloakError(msg)
         else:
-            # bossadmin user cannot be deleted.
-            if user_name == 'bossadmin':
-                msg = "Cannot delete user bossadmin from Keycloak".format(user_name)
-                return BossKeycloakError(msg)
-            else:
-                try:
-                    with KeyCloakClient('BOSS') as kc:
-                        kc.delete_user(user_name)
+            try:
+                with KeyCloakClient('BOSS') as kc:
+                    kc.delete_user(user_name)
 
-                    return Response(status=204)
-                except KeyCloakError:
-                    msg = "Error deleting user '{}' from Keycloak".format(user_name)
-                    return BossKeycloakError(msg)
+                return Response(status=204)
+            except KeyCloakError:
+                msg = "Error deleting user '{}' from Keycloak".format(user_name)
+                return BossKeycloakError(msg)
 
 class BossUserRole(APIView):
     """

--- a/django/sso/views/views_user.py
+++ b/django/sso/views/views_user.py
@@ -163,14 +163,23 @@ class BossUser(APIView):
             None
         """
         # DP TODO: verify user_name is not an admin
-        try:
-            with KeyCloakClient('BOSS') as kc:
-                kc.delete_user(user_name)
+        
 
-            return Response(status=204)
-        except KeyCloakError:
-            msg = "Error deleting user '{}' from Keycloak".format(user_name)
+        # bossadmin user cannot be deleted.
+        if user_name == 'bossadmin':
+            msg = "Cannot delete user bossadmin from Keycloak".format(user_name)
             return BossKeycloakError(msg)
+        else:
+            try:
+                with KeyCloakClient('BOSS') as kc:
+                    kc.delete_user(user_name)
+
+                return Response(status=204)
+            except KeyCloakError:
+                msg = "Error deleting user '{}' from Keycloak".format(user_name)
+                return BossKeycloakError(msg)
+
+print(delete('bossadmin'))
 
 class BossUserRole(APIView):
     """

--- a/django/sso/views/views_user.py
+++ b/django/sso/views/views_user.py
@@ -163,23 +163,23 @@ class BossUser(APIView):
             None
         """
         # DP TODO: verify user_name is not an admin
-        
-
-        # bossadmin user cannot be deleted.
-        if user_name == 'bossadmin':
-            msg = "Cannot delete user bossadmin from Keycloak".format(user_name)
-            return BossKeycloakError(msg)
+        bp = BossPrivilegeManager(user_name)
+        if bp.has_role('admin'):
+            return BossKeycloakError('The user is an admin')
         else:
-            try:
-                with KeyCloakClient('BOSS') as kc:
-                    kc.delete_user(user_name)
-
-                return Response(status=204)
-            except KeyCloakError:
-                msg = "Error deleting user '{}' from Keycloak".format(user_name)
+            # bossadmin user cannot be deleted.
+            if user_name == 'bossadmin':
+                msg = "Cannot delete user bossadmin from Keycloak".format(user_name)
                 return BossKeycloakError(msg)
+            else:
+                try:
+                    with KeyCloakClient('BOSS') as kc:
+                        kc.delete_user(user_name)
 
-print(delete('bossadmin'))
+                    return Response(status=204)
+                except KeyCloakError:
+                    msg = "Error deleting user '{}' from Keycloak".format(user_name)
+                    return BossKeycloakError(msg)
 
 class BossUserRole(APIView):
     """


### PR DESCRIPTION
A couple of lines of code to make sure that bossadmin cannot be deleted as a maintainer from any groups. 
I ran all unit-tests and created and tested a new one to ensure this continues to be successful in the future. 
All tests successful. 