### PR TITLE
Admin redownsample

### DIFF
--- a/django/bossspatialdb/views.py
+++ b/django/bossspatialdb/views.py
@@ -305,7 +305,7 @@ class Downsample(APIView):
                     try:
                         cache = RedisKVIO(settings.KVIO_SETTINGS)
                         pipe = cache.cache_client.pipeline()
-                        for key in pipe.scan_iter(match=pattern):
+                        for key in cache.scan_iter(match=pattern):
                             pipe.delete(key)
                         pipe.execute()
                     except Exception as ex:

--- a/django/bossspatialdb/views.py
+++ b/django/bossspatialdb/views.py
@@ -17,6 +17,7 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import authentication, permissions
 from rest_framework.renderers import JSONRenderer, BrowsableAPIRenderer
+from rest_framework.parsers import JSONParser
 
 from .parsers import BloscParser, BloscPythonParser, NpygzParser, is_too_large
 from .renderers import BloscRenderer, BloscPythonRenderer, NpygzRenderer, JpegRenderer
@@ -234,7 +235,7 @@ class Downsample(APIView):
     * Requires authentication.
     """
     # Set Parser and Renderer
-    parser_classes = (JSONRenderer, BrowsableAPIRenderer)
+    parser_classes = (JSONParser, BrowsableAPIRenderer)
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
     def get(self, request, collection, experiment, channel):
@@ -291,6 +292,8 @@ class Downsample(APIView):
                 channel_obj.downsample_status = "DOWNSAMPLED"
                 channel_obj.save()
                 to_renderer["status"] = "DOWNSAMPLED"
+
+                # DP TODO: Clear cache of any data from the channel
 
             elif status == "FAILED" or status == "TIMED_OUT":
                 # Change status to FAILED
@@ -356,8 +359,15 @@ class Downsample(APIView):
         channel = resource.get_channel()
         if channel.downsample_status.upper() == "IN_PROGRESS":
             return BossHTTPError("Channel is currently being downsampled. Invalid Request.", ErrorCodes.INVALID_STATE)
-        elif channel.downsample_status.upper() == "DOWNSAMPLED":
+        elif channel.downsample_status.upper() == "DOWNSAMPLED" and \
+             not request.user.is_staff:
             return BossHTTPError("Channel is already downsampled. Invalid Request.", ErrorCodes.INVALID_STATE)
+
+        if request.user.is_staff:
+            # DP HACK: allow admin users to override the coordinate frame
+            frame = request.data
+        else:
+            frame = {}
 
         # Call Step Function
         boss_config = bossutils.configuration.BossConfig()
@@ -365,6 +375,10 @@ class Downsample(APIView):
         coord_frame = resource.get_coord_frame()
         lookup_key = resource.get_lookup_key()
         col_id, exp_id, ch_id = lookup_key.split("&")
+
+        def get_frame(idx):
+            return int(frame.get(idx, getattr(coord_frame, idx)))
+
         args = {
             'collection_id': int(col_id),
             'experiment_id': int(exp_id),
@@ -375,13 +389,13 @@ class Downsample(APIView):
             's3_bucket': boss_config["aws"]["cuboid_bucket"],
             's3_index': boss_config["aws"]["s3-index-table"],
 
-            'x_start': int(coord_frame.x_start),
-            'y_start': int(coord_frame.y_start),
-            'z_start': int(coord_frame.z_start),
+            'x_start': get_frame('x_start'),
+            'y_start': get_frame('y_start'),
+            'z_start': get_frame('z_start'),
 
-            'x_stop': int(coord_frame.x_stop),
-            'y_stop': int(coord_frame.y_stop),
-            'z_stop': int(coord_frame.z_stop),
+            'x_stop': get_frame('x_stop'),
+            'y_stop': get_frame('y_stop'),
+            'z_stop': get_frame('z_stop'),
 
             'resolution': int(channel.base_resolution),
             'resolution_max': int(experiment.num_hierarchy_levels),

--- a/django/bossspatialdb/views.py
+++ b/django/bossspatialdb/views.py
@@ -295,6 +295,9 @@ class Downsample(APIView):
                 channel_obj.save()
                 to_renderer["status"] = "DOWNSAMPLED"
 
+                # DP NOTE: This code should be moved to spdb when change
+                #          tracking is added to automatically calculate
+                #          frame extents for the user
                 # DP NOTE: Clear the cache of any cubes for the channel
                 #          This is to prevent serving stale data after
                 #          (re)downsampling

--- a/django/bossspatialdb/views.py
+++ b/django/bossspatialdb/views.py
@@ -305,7 +305,7 @@ class Downsample(APIView):
                     try:
                         cache = RedisKVIO(settings.KVIO_SETTINGS)
                         pipe = cache.cache_client.pipeline()
-                        for key in cache.scan_iter(match=pattern):
+                        for key in cache.cache_client.scan_iter(match=pattern):
                             pipe.delete(key)
                         pipe.execute()
                     except Exception as ex:

--- a/django/bossspatialdb/views.py
+++ b/django/bossspatialdb/views.py
@@ -301,7 +301,7 @@ class Downsample(APIView):
                 try:
                     cache = RedisKVIO(settings.KVIO_SETTINGS)
                     pipe = cache.cache_client.pipeline()
-                    for key in pipe.scan_iter("CACHED-CUBOID&"+lookup_key+"&*"):
+                    for key in pipe.scan_iter("CACHED-CUBOID*&"+lookup_key+"&*"):
                         pipe.delete(key)
                     pipe.execute()
                 except Exception as ex:

--- a/django/mgmt/templates/base.html
+++ b/django/mgmt/templates/base.html
@@ -147,8 +147,8 @@
 <script type="text/javascript" src="{% static "js/tour.js" %}"></script>
 <script type="text/javascript">
   //var API_ROOT= window.location.protocol + "//" + window.location.hostname + "/" + window.location.pathname.split("/")[1] + "/";
-  var API_ROOT = window.location.protocol + "//" + window.location.hostname + "/" + "{% url 'mgmt:home' %}".split("/")[1] + "/";
-  var MGMT_ROOT = window.location.protocol + "//" + window.location.hostname + "{% url 'mgmt:home' %}";
+  var API_ROOT = window.location.protocol + "//" + window.location.host + "/" + "{% url 'mgmt:home' %}".split("/")[1] + "/";
+  var MGMT_ROOT = window.location.protocol + "//" + window.location.host + "{% url 'mgmt:home' %}";
   var USER_ROLES= {% autoescape off %}{{ user_roles }}{% endautoescape %};
 </script>
 

--- a/django/mgmt/templates/channel.html
+++ b/django/mgmt/templates/channel.html
@@ -38,6 +38,10 @@
                                     <div class="panel-body">
                                         <a id="downsample-btn" type='button' class='btn btn-primary btn-sm action-button disabled' href='javascript:void(0);' onclick='start_downsample("{{ collection_name }}", "{{ experiment_name }}", "{{ channel_name }}")'><span class='glyphicon glyphicon-sort-by-attributes-alt' aria-hidden='true'></span> Start Downsample</a>
                                         <a id="cancel-btn" type='button' class='btn btn-danger btn-sm action-button disabled' href='javascript:void(0);' onclick='cancel_downsample("{{collection_name }}", "{{ experiment_name }}", "{{ channel_name }}")'><span class='glyphicon glyphicon-remove' aria-hidden='true'></span> Cancel Downsample</a>
+                                        {% if user.is_staff %}
+                                            <br/><br />
+                                            <a id="redownsample-btn" type='button' class='btn btn-primary btn-sm action-button' href='javascript:void(0);' onclick='start_redownsample("{{ collection_name }}", "{{ experiment_name }}", "{{ channel_name }}")'><span class='glyphicon glyphicon-sort-by-attributes-alt' aria-hidden='true'></span> Start Re-downsample</a>
+                                        {% endif %}
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Modification that allows an admin (Keycloak `admin` role / Django `is_staff` flag) to request a re-downsample of a channel with a different coordinate frame. This appears as a new button next to the current downsample buttons on the channel page in the management console.

In addition after any channel is downsampled the redis cache is cleared of any keys from that channel so that we don't accidentally continue serve up stale data after it has been changed.

Testing has not been completed but will be before the PR is merged.