### PR TITLE
Pass 'function-name' when invoking ingest lambda.

### DIFF
--- a/django/bossingest/ingest_manager.py
+++ b/django/bossingest/ingest_manager.py
@@ -637,6 +637,7 @@ class IngestManager:
 
         event = {"ingest_job": ingest_job.id,
                  "chunk_key": fake_chunk_key,
+                 "function-name": INGEST_LAMBDA,
                  "lambda-name": "ingest"}
 
         # Invoke Ingest lambda functions


### PR DESCRIPTION
The ingest lambda needs this to figure out the domain its running in so
it can look up names of other lambdas.  When it is no longer part of the
multilambda, it can determine its domain from the Context object passed
in during lambda invocation.