### PR TITLE
Raw no cache mode feature

### DIFF
--- a/django/boss/utils.py
+++ b/django/boss/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
+# Copyright 2018 The Johns Hopkins University Applied Physics Laboratory
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,64 +12,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from rest_framework.views import APIView
-from rest_framework.response import Response
-from rest_framework import authentication, permissions
-from rest_framework.renderers import JSONRenderer, BrowsableAPIRenderer
+from bosscore.error import BossHTTPError, ErrorCodes
 
-from django.http import HttpResponse
-from django.conf import settings
+def get_access_mode(request):
+    """
+        Method to check the request parameters and define access_mode
 
-from bosscore.request import BossRequest
-from bosscore.error import BossError, BossHTTPError, BossParserError, ErrorCodes
-from bosscore.models import Channel
+        Args:
+            request : url request
 
-from bossutils.logger import BossLogger
+        Returns:
+            access_mode (str) : Defines whether to use cache or not. Possible inputs are cache, no_cache or raw.
+        
+        Raises: 
+            BossHTTPError if given invalid access-mode or no-cache values.
 
-class BossUtils(object):
+    """
 
-    @staticmethod
-    def get_access_mode(request):
-        """
-            Method to check the request parameters and define access_mode
+    #Default access_mode to cache on the server side in case it is not explicitly defined in an API call. 
+    access_mode = "cache"
 
-            Args:
-                request : url request
+    #Raise an error if both no-cache and access_mode are on the request URL
+    if "no-cache" in request.query_params and "access-mode" in request.query_params:
+        return BossHTTPError("access_mode and no-cache specified  in URL, please specify access_mode. no-cache will be deprecated.", ErrorCodes.INVALID_CUTOUT_ARGS)
 
-            Returns:
-                access_mode (str) : Defines whether to use cache or not. Possible inputs are cache, no_cache or raw.
+    #Translation from no-cache boolean param to access_mode param for backwards compatability. 
+    if "no-cache" in request.query_params:
+        if request.query_params["no-cache"].lower() == "true":
+            access_mode = "no_cache"
+        elif request.query_params["no-cache"].lower() == "false":
+            access_mode = "cache"
+        else:
+            return BossHTTPError("Incorrect no-cache value. Must be True or False.", ErrorCodes.INVALID_CUTOUT_ARGS)
             
-            Raises: 
-                BossHTTPError if given invalid access-mode or no-cache values.
-
-        """
-        boss_logger = BossLogger()
-        boss_logger.setLevel("info")
-        blog = boss_logger.logger
-
-        #Default access_mode to cache on the server side in case it is not explicitly defined in an API call. 
-        access_mode = "cache"
-
-        #Raise an error if both no-cache and access_mode are on the request URL
-        if "no-cache" in request.query_params and "access-mode" in request.query_params:
-            return BossHTTPError("access_mode and no-cache specified  in URL, please specify access_mode. no-cache will be deprecated.", ErrorCodes.INVALID_CUTOUT_ARGS)
-
-        #Translation from no-cache boolean param to access_mode param for backwards compatability. 
-        if "no-cache" in request.query_params:
-            if request.query_params["no-cache"].lower() == "true":
-                access_mode = "no_cache"
-            elif request.query_params["no-cache"].lower() == "false":
-                access_mode = "cache"
-            else:
-                return BossHTTPError("Incorrect no-cache value. Must be True or False.", ErrorCodes.INVALID_CUTOUT_ARGS)
-                
-        if "access-mode" in request.query_params:
-            if request.query_params["access-mode"].lower() == "raw":
-                access_mode = "raw"
-            elif request.query_params["access-mode"].lower() == "no-cache":
-                access_mode = "no_cache"
-            elif request.query_params["access-mode"].lower() == "cache":
-                access_mode = "cache"
-            else:
-                return BossHTTPError("Incorrect access_mode, possible values are [raw, no-cache, cache]", ErrorCodes.INVALID_CUTOUT_ARGS)
-        return access_mode
+    if "access-mode" in request.query_params:
+        if request.query_params["access-mode"].lower() == "raw":
+            access_mode = "raw"
+        elif request.query_params["access-mode"].lower() == "no-cache":
+            access_mode = "no_cache"
+        elif request.query_params["access-mode"].lower() == "cache":
+            access_mode = "cache"
+        else:
+            return BossHTTPError("Incorrect access_mode, possible values are [raw, no-cache, cache]", ErrorCodes.INVALID_CUTOUT_ARGS)
+    return access_mode

--- a/django/boss/utils.py
+++ b/django/boss/utils.py
@@ -1,0 +1,75 @@
+# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import authentication, permissions
+from rest_framework.renderers import JSONRenderer, BrowsableAPIRenderer
+
+from django.http import HttpResponse
+from django.conf import settings
+
+from bosscore.request import BossRequest
+from bosscore.error import BossError, BossHTTPError, BossParserError, ErrorCodes
+from bosscore.models import Channel
+
+from bossutils.logger import BossLogger
+
+class BossUtils(object):
+
+    @staticmethod
+    def get_access_mode(request):
+        """
+            Method to check the request parameters and define access_mode
+
+            Args:
+                request : url request
+
+            Returns:
+                access_mode (str) : Defines whether to use cache or not. Possible inputs are cache, no_cache or raw.
+            
+            Raises: 
+                BossHTTPError if given invalid access-mode or no-cache values.
+
+        """
+        boss_logger = BossLogger()
+        boss_logger.setLevel("info")
+        blog = boss_logger.logger
+
+        #Default access_mode to cache on the server side in case it is not explicitly defined in an API call. 
+        access_mode = "cache"
+
+        #Raise an error if both no-cache and access_mode are on the request URL
+        if "no-cache" in request.query_params and "access-mode" in request.query_params:
+            return BossHTTPError("access_mode and no-cache specified  in URL, please specify access_mode. no-cache will be deprecated.", ErrorCodes.INVALID_CUTOUT_ARGS)
+
+        #Translation from no-cache boolean param to access_mode param for backwards compatability. 
+        if "no-cache" in request.query_params:
+            if request.query_params["no-cache"].lower() == "true":
+                access_mode = "no_cache"
+            elif request.query_params["no-cache"].lower() == "false":
+                access_mode = "cache"
+            else:
+                return BossHTTPError("Incorrect no-cache value. Must be True or False.", ErrorCodes.INVALID_CUTOUT_ARGS)
+                
+        if "access-mode" in request.query_params:
+            if request.query_params["access-mode"].lower() == "raw":
+                access_mode = "raw"
+            elif request.query_params["access-mode"].lower() == "no-cache":
+                access_mode = "no_cache"
+            elif request.query_params["access-mode"].lower() == "cache":
+                access_mode = "cache"
+            else:
+                return BossHTTPError("Incorrect access_mode, possible values are [raw, no-cache, cache]", ErrorCodes.INVALID_CUTOUT_ARGS)
+        return access_mode

--- a/django/bossspatialdb/views.py
+++ b/django/bossspatialdb/views.py
@@ -79,6 +79,13 @@ class Cutout(APIView):
         else:
             iso = False
 
+        #Translation from no-cache boolean param to access_mode param for backwards compatability. 
+        if "no-cache" in request.query_params:
+            if request.query_params["no-cache"].lower() == "true":
+                access_mode = "no_cache"
+            elif request.query_params["no-cache"].lower() == "false":
+                access_mode = "cache"
+                
         if "access_mode" in request.query_params:
             if request.query_params["access_mode"].lower() == "raw":
                 access_mode = "raw"

--- a/django/bossspatialdb/views.py
+++ b/django/bossspatialdb/views.py
@@ -28,7 +28,7 @@ from bosscore.request import BossRequest
 from bosscore.error import BossError, BossHTTPError, BossParserError, ErrorCodes
 from bosscore.models import Channel
 
-from boss.utils import BossUtils
+from boss import utils
 
 from spdb.spatialdb.spatialdb import SpatialDB, CUBOIDSIZE
 from spdb import project
@@ -82,7 +82,7 @@ class Cutout(APIView):
             iso = False
 
         # Define access mode.
-        access_mode = BossUtils.get_access_mode(request)
+        access_mode = utils.get_access_mode(request)
 
         if isinstance(request.data, BossParserError):
             return request.data.to_http()

--- a/django/bossspatialdb/views.py
+++ b/django/bossspatialdb/views.py
@@ -28,6 +28,8 @@ from bosscore.request import BossRequest
 from bosscore.error import BossError, BossHTTPError, BossParserError, ErrorCodes
 from bosscore.models import Channel
 
+from boss.utils import BossUtils
+
 from spdb.spatialdb.spatialdb import SpatialDB, CUBOIDSIZE
 from spdb import project
 import bossutils
@@ -79,22 +81,8 @@ class Cutout(APIView):
         else:
             iso = False
 
-        #Default access_mode to cache on the server side in case it is not explicitly defined in an API call. 
-        access_mode = "cache"
-        #Translation from no-cache boolean param to access_mode param for backwards compatability. 
-        if "no-cache" in request.query_params:
-            if request.query_params["no-cache"].lower() == "true":
-                access_mode = "no_cache"
-            elif request.query_params["no-cache"].lower() == "false":
-                access_mode = "cache"
-                
-        if "access_mode" in request.query_params:
-            if request.query_params["access_mode"].lower() == "raw":
-                access_mode = "raw"
-            elif request.query_params["access_mode"].lower() == "no-cache":
-                access_mode = "no_cache"
-            else:
-                access_mode = "cache"
+        # Define access mode.
+        access_mode = BossUtils.get_access_mode(request)
 
         if isinstance(request.data, BossParserError):
             return request.data.to_http()

--- a/django/bossspatialdb/views.py
+++ b/django/bossspatialdb/views.py
@@ -79,13 +79,13 @@ class Cutout(APIView):
         else:
             iso = False
 
-        if "no-cache" in request.query_params:
-            if request.query_params["no-cache"].lower() == "true":
-                no_cache = True
-            else:
-                no_cache = False
+        if "access_mode" in request.query_params:
+            if request.query_params["access_mode"].lower() == "raw":
+                access_mode = "raw"
+            elif request.query_params["access_mode"].lower() == "no_cache":
+                access_mode = "no_cache"
         else:
-            no_cache = False
+            access_mode = "cache"
 
         if isinstance(request.data, BossParserError):
             return request.data.to_http()
@@ -133,7 +133,7 @@ class Cutout(APIView):
 
         # Get a Cube instance with all time samples
         data = cache.cutout(resource, corner, extent, req.get_resolution(), [req.get_time().start, req.get_time().stop],
-                            filter_ids=req.get_filter_ids(), iso=iso, no_cache=no_cache)
+                            filter_ids=req.get_filter_ids(), iso=iso, access_mode=access_mode)
         to_renderer = {"time_request": req.time_request,
                        "data": data}
 

--- a/django/bossspatialdb/views.py
+++ b/django/bossspatialdb/views.py
@@ -79,6 +79,8 @@ class Cutout(APIView):
         else:
             iso = False
 
+        #Default access_mode to cache on the server side in case it is not explicitly defined in an API call. 
+        access_mode = "cache"
         #Translation from no-cache boolean param to access_mode param for backwards compatability. 
         if "no-cache" in request.query_params:
             if request.query_params["no-cache"].lower() == "true":

--- a/django/bossspatialdb/views.py
+++ b/django/bossspatialdb/views.py
@@ -82,7 +82,7 @@ class Cutout(APIView):
         if "access_mode" in request.query_params:
             if request.query_params["access_mode"].lower() == "raw":
                 access_mode = "raw"
-            elif request.query_params["access_mode"].lower() == "no_cache":
+            elif request.query_params["access_mode"].lower() == "no-cache":
                 access_mode = "no_cache"
         else:
             access_mode = "cache"

--- a/django/bossspatialdb/views.py
+++ b/django/bossspatialdb/views.py
@@ -91,8 +91,8 @@ class Cutout(APIView):
                 access_mode = "raw"
             elif request.query_params["access_mode"].lower() == "no-cache":
                 access_mode = "no_cache"
-        else:
-            access_mode = "cache"
+            else:
+                access_mode = "cache"
 
         if isinstance(request.data, BossParserError):
             return request.data.to_http()

--- a/django/bosstiles/views.py
+++ b/django/bosstiles/views.py
@@ -74,7 +74,7 @@ class CutoutTile(APIView):
         if "access_mode" in request.query_params:
             if request.query_params["access_mode"].lower() == "raw":
                 access_mode = "raw"
-            elif request.query_params["access_mode"].lower() == "no_cache":
+            elif request.query_params["access_mode"].lower() == "no-cache":
                 access_mode = "no_cache"
         else:
             access_mode = "cache"
@@ -173,7 +173,7 @@ class Tile(APIView):
         if "access_mode" in request.query_params:
             if request.query_params["access_mode"].lower() == "raw":
                 access_mode = "raw"
-            elif request.query_params["access_mode"].lower() == "no_cache":
+            elif request.query_params["access_mode"].lower() == "no-cache":
                 access_mode = "no_cache"
         else:
             access_mode = "cache"

--- a/django/bosstiles/views.py
+++ b/django/bosstiles/views.py
@@ -71,13 +71,13 @@ class CutoutTile(APIView):
         except BossError as err:
             return err.to_http()
 
-        if "no-cache" in request.query_params:
-            if request.query_params["no-cache"].lower() == "true":
-                no_cache = True
-            else:
-                no_cache = False
+        if "access_mode" in request.query_params:
+            if request.query_params["access_mode"].lower() == "raw":
+                access_mode = "raw"
+            elif request.query_params["access_mode"].lower() == "no_cache":
+                access_mode = "no_cache"
         else:
-            no_cache = False
+            access_mode = "cache"
 
         # Convert to Resource
         resource = spdb.project.BossResourceDjango(req)
@@ -105,7 +105,7 @@ class CutoutTile(APIView):
 
         # Do a cutout as specified
         data = cache.cutout(resource, corner, extent, req.get_resolution(),
-                            [req.get_time().start, req.get_time().stop], no_cache=no_cache)
+                            [req.get_time().start, req.get_time().stop], access_mode=access_mode)
 
         # Covert the cutout back to an image and return it
         if orientation == 'xy':
@@ -170,13 +170,13 @@ class Tile(APIView):
         except BossError as err:
             return err.to_http()
 
-        if "no-cache" in request.query_params:
-            if request.query_params["no-cache"].lower() == "true":
-                no_cache = True
-            else:
-                no_cache = False
+        if "access_mode" in request.query_params:
+            if request.query_params["access_mode"].lower() == "raw":
+                access_mode = "raw"
+            elif request.query_params["access_mode"].lower() == "no_cache":
+                access_mode = "no_cache"
         else:
-            no_cache = False
+            access_mode = "cache"
 
         # Convert to Resource
         resource = spdb.project.BossResourceDjango(req)
@@ -204,7 +204,7 @@ class Tile(APIView):
 
         # Do a cutout as specified
         data = cache.cutout(resource, corner, extent, req.get_resolution(),
-                            [req.get_time().start, req.get_time().stop], no_cache=no_cache)
+                            [req.get_time().start, req.get_time().stop], access_mode=access_mode)
 
         # Covert the cutout back to an image and return it
         if orientation == 'xy':

--- a/django/bosstiles/views.py
+++ b/django/bosstiles/views.py
@@ -70,6 +70,13 @@ class CutoutTile(APIView):
             req = BossRequest(request, request_args)
         except BossError as err:
             return err.to_http()
+            
+        #Translation from no-cache boolean param to access_mode param for backwards compatability. 
+        if "no-cache" in request.query_params:
+            if request.query_params["no-cache"].lower() == "true":
+                access_mode = "no_cache"
+            elif request.query_params["no-cache"].lower() == "false":
+                access_mode = "cache"
 
         if "access_mode" in request.query_params:
             if request.query_params["access_mode"].lower() == "raw":
@@ -169,6 +176,13 @@ class Tile(APIView):
             req = BossRequest(request, request_args)
         except BossError as err:
             return err.to_http()
+
+        #Translation from no-cache boolean param to access_mode param for backwards compatability. 
+        if "no-cache" in request.query_params:
+            if request.query_params["no-cache"].lower() == "true":
+                access_mode = "no_cache"
+            elif request.query_params["no-cache"].lower() == "false":
+                access_mode = "cache"
 
         if "access_mode" in request.query_params:
             if request.query_params["access_mode"].lower() == "raw":

--- a/django/bosstiles/views.py
+++ b/django/bosstiles/views.py
@@ -70,7 +70,7 @@ class CutoutTile(APIView):
             req = BossRequest(request, request_args)
         except BossError as err:
             return err.to_http()
-            
+
         #Translation from no-cache boolean param to access_mode param for backwards compatability. 
         if "no-cache" in request.query_params:
             if request.query_params["no-cache"].lower() == "true":
@@ -83,8 +83,8 @@ class CutoutTile(APIView):
                 access_mode = "raw"
             elif request.query_params["access_mode"].lower() == "no-cache":
                 access_mode = "no_cache"
-        else:
-            access_mode = "cache"
+            else:
+                access_mode = "cache"
 
         # Convert to Resource
         resource = spdb.project.BossResourceDjango(req)
@@ -189,8 +189,8 @@ class Tile(APIView):
                 access_mode = "raw"
             elif request.query_params["access_mode"].lower() == "no-cache":
                 access_mode = "no_cache"
-        else:
-            access_mode = "cache"
+            else:
+                access_mode = "cache"
 
         # Convert to Resource
         resource = spdb.project.BossResourceDjango(req)

--- a/django/bosstiles/views.py
+++ b/django/bosstiles/views.py
@@ -16,11 +16,9 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from django.conf import settings
 
-from boss.utils import BossUtils
+from boss import utils
 from bosscore.request import BossRequest
 from bosscore.error import BossError, BossHTTPError, ErrorCodes
-
-from bossutils.logger import BossLogger
 
 import spdb
 
@@ -75,8 +73,7 @@ class CutoutTile(APIView):
             return err.to_http()
 
         #Define access mode
-        access_mode = BossUtils.get_access_mode(request)
-        
+        access_mode = utils.get_access_mode(request)
 
         # Convert to Resource
         resource = spdb.project.BossResourceDjango(req)
@@ -170,7 +167,7 @@ class Tile(APIView):
             return err.to_http()
 
         #Define access_mode
-        access_mode = BossUtils.get_access_mode(request)
+        access_mode = utils.get_access_mode(request)
 
         # Convert to Resource
         resource = spdb.project.BossResourceDjango(req)

--- a/django/bosstiles/views.py
+++ b/django/bosstiles/views.py
@@ -16,8 +16,11 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from django.conf import settings
 
+from boss.utils import BossUtils
 from bosscore.request import BossRequest
 from bosscore.error import BossError, BossHTTPError, ErrorCodes
+
+from bossutils.logger import BossLogger
 
 import spdb
 
@@ -71,22 +74,9 @@ class CutoutTile(APIView):
         except BossError as err:
             return err.to_http()
 
-        #Default access_mode to cache on the server side in case it is not explicitly defined in an API call. 
-        access_mode = "cache"
-        #Translation from no-cache boolean param to access_mode param for backwards compatability. 
-        if "no-cache" in request.query_params:
-            if request.query_params["no-cache"].lower() == "true":
-                access_mode = "no_cache"
-            elif request.query_params["no-cache"].lower() == "false":
-                access_mode = "cache"
-
-        if "access_mode" in request.query_params:
-            if request.query_params["access_mode"].lower() == "raw":
-                access_mode = "raw"
-            elif request.query_params["access_mode"].lower() == "no-cache":
-                access_mode = "no_cache"
-            else:
-                access_mode = "cache"
+        #Define access mode
+        access_mode = BossUtils.get_access_mode(request)
+        
 
         # Convert to Resource
         resource = spdb.project.BossResourceDjango(req)
@@ -179,22 +169,8 @@ class Tile(APIView):
         except BossError as err:
             return err.to_http()
 
-        #Default access_mode to cache on the server side in case it is not explicitly defined in an API call. 
-        access_mode = "cache"
-        #Translation from no-cache boolean param to access_mode param for backwards compatability. 
-        if "no-cache" in request.query_params:
-            if request.query_params["no-cache"].lower() == "true":
-                access_mode = "no_cache"
-            elif request.query_params["no-cache"].lower() == "false":
-                access_mode = "cache"
-
-        if "access_mode" in request.query_params:
-            if request.query_params["access_mode"].lower() == "raw":
-                access_mode = "raw"
-            elif request.query_params["access_mode"].lower() == "no-cache":
-                access_mode = "no_cache"
-            else:
-                access_mode = "cache"
+        #Define access_mode
+        access_mode = BossUtils.get_access_mode(request)
 
         # Convert to Resource
         resource = spdb.project.BossResourceDjango(req)

--- a/django/bosstiles/views.py
+++ b/django/bosstiles/views.py
@@ -71,6 +71,8 @@ class CutoutTile(APIView):
         except BossError as err:
             return err.to_http()
 
+        #Default access_mode to cache on the server side in case it is not explicitly defined in an API call. 
+        access_mode = "cache"
         #Translation from no-cache boolean param to access_mode param for backwards compatability. 
         if "no-cache" in request.query_params:
             if request.query_params["no-cache"].lower() == "true":
@@ -177,6 +179,8 @@ class Tile(APIView):
         except BossError as err:
             return err.to_http()
 
+        #Default access_mode to cache on the server side in case it is not explicitly defined in an API call. 
+        access_mode = "cache"
         #Translation from no-cache boolean param to access_mode param for backwards compatability. 
         if "no-cache" in request.query_params:
             if request.query_params["no-cache"].lower() == "true":


### PR DESCRIPTION
This pull request is related to jhuapl-boss/spdb#9.

- The changes to the boss repository include checks to correctly assign the `access_mode` variable the correct string value depending on what the query parameters have specified. 
- Note that it is in _this_ PR that we translate the no_cache option available in previous versions of the code to the new `access_code` 

The translation of the `no_cache` param to the `access_mode` param was necessary to ensure that a cutout is grabbed making a direct API call rather than using intern, the system knows how to handle the old `no_cache` param. NOTE however that this is also done in `intern` client side. 

Please see jhuapl-boss/spdb#9 for testing procedure. 
