### PR TITLE
Tile queue update

### DIFF
--- a/django/bossingest/ingest_manager.py
+++ b/django/bossingest/ingest_manager.py
@@ -505,7 +505,7 @@ class IngestManager:
         """
         queue = TileIndexQueue(self.nd_proj, endpoint_url=None)
         self.remove_trigger_tile_uploaded_lambda_from_queue(queue.arn)
-        queue.deleteQueue(self.nd_proj, endpoint_url=None)
+        queue.deleteQueue(self.nd_proj, endpoint_url=None, delete_deadletter_queue=True)
 
     def delete_tile_error_queue(self):
         """

--- a/django/bossingest/ingest_manager.py
+++ b/django/bossingest/ingest_manager.py
@@ -15,23 +15,24 @@
 import json
 import jsonschema
 import boto3
-import io
 import math
 from django.utils import timezone
 
 from ingestclient.core.config import Configuration
 from ingestclient.core.backend import BossBackend
 
-from bossingest.serializers import IngestJobCreateSerializer, IngestJobListSerializer
+from bossingest.serializers import IngestJobCreateSerializer
 from bossingest.models import IngestJob
 from bossingest.utils import query_tile_index, patch_upload_queue
 
-from bosscore.error import BossError, ErrorCodes, BossResourceNotFoundError
+from bosscore.error import BossError, ErrorCodes
 from bosscore.models import Collection, Experiment, Channel
 from bosscore.lookup import LookUpKey
 
 from ndingest.ndqueue.uploadqueue import UploadQueue
 from ndingest.ndqueue.ingestqueue import IngestQueue
+from ndingest.ndqueue.tileindexqueue import TileIndexQueue
+from ndingest.ndqueue.tileerrorqueue import TileErrorQueue
 from ndingest.ndingestproj.bossingestproj import BossIngestProj
 from ndingest.nddynamo.boss_tileindexdb import BossTileIndexDB
 from ndingest.ndbucket.tilebucket import TileBucket
@@ -179,6 +180,8 @@ class IngestManager:
                 if self.job.ingest_type == IngestJob.TILE_INGEST:
                     ingest_queue = self.create_ingest_queue()
                     self.job.ingest_queue = ingest_queue.url
+                    self.create_tile_index_queue()
+                    self.create_tile_error_queue()
                 elif self.job.ingest_type == IngestJob.VOLUMETRIC_INGEST:
                     # Will the management console be ok with ingest_queue being null?
                     pass
@@ -317,6 +320,36 @@ class IngestManager:
         queue = UploadQueue(self.nd_proj, endpoint_url=None)
         return queue
 
+    def get_ingest_job_tile_index_queue(self, ingest_job):
+        """
+        Return the tile index queue for an ingest job
+        Args:
+            ingest_job: Ingest job model
+
+        Returns:
+            ndingest.TileIndexQueue
+        """
+        proj_class = BossIngestProj.load()
+        self.nd_proj = proj_class(ingest_job.collection, ingest_job.experiment, ingest_job.channel,
+                                  ingest_job.resolution, ingest_job.id)
+        queue = TileIndexQueue(self.nd_proj, endpoint_url=None)
+        return queue
+
+    def get_ingest_job_tile_error_queue(self, ingest_job):
+        """
+        Return the tile index queue for an ingest job
+        Args:
+            ingest_job: Ingest job model
+
+        Returns:
+            ndingest.TileIndexQueue
+        """
+        proj_class = BossIngestProj.load()
+        self.nd_proj = proj_class(ingest_job.collection, ingest_job.experiment, ingest_job.channel,
+                                  ingest_job.resolution, ingest_job.id)
+        queue = TileErrorQueue(self.nd_proj, endpoint_url=None)
+        return queue
+
     def get_ingest_job_ingest_queue(self, ingest_job):
         """
         Return the ingest queue for an ingest job
@@ -379,10 +412,12 @@ class IngestManager:
             self.nd_proj = proj_class(ingest_job.collection, ingest_job.experiment, ingest_job.channel,
                                       ingest_job.resolution, ingest_job.id)
 
-            # delete the ingest and upload_queue
+            # delete the queues
             self.delete_upload_queue()
             if ingest_job.ingest_type != IngestJob.VOLUMETRIC_INGEST:
                 self.delete_ingest_queue()
+                self.delete_tile_index_queue()
+                self.delete_tile_error_queue()
 
             # delete any pending entries in the tile index database and tile bucket
             # Commented out due to removal of tile index's GSI.
@@ -414,6 +449,28 @@ class IngestManager:
         queue = UploadQueue(self.nd_proj, endpoint_url=None)
         return queue
 
+    def create_tile_index_queue(self):
+        """
+        Create an tile index queue for an ingest job using the ndingest library
+        Returns:
+            UploadQueue : Returns a tile index queue object
+
+        """
+        TileIndexQueue.createQueue(self.nd_proj, endpoint_url=None)
+        queue = TileIndexQueue(self.nd_proj, endpoint_url=None)
+        return queue
+
+    def create_tile_error_queue(self):
+        """
+        Create an tile error queue for an ingest job using the ndingest library
+        Returns:
+            UploadQueue : Returns a tile index queue object
+
+        """
+        TileErrorQueue.createQueue(self.nd_proj, endpoint_url=None)
+        queue = TileErrorQueue(self.nd_proj, endpoint_url=None)
+        return queue
+
     def create_ingest_queue(self):
         """
         Create an ingest queue for an ingest job using the ndingest library
@@ -433,6 +490,24 @@ class IngestManager:
 
         """
         UploadQueue.deleteQueue(self.nd_proj, endpoint_url=None)
+
+    def delete_tile_index_queue(self):
+        """
+        Delete the current upload queue
+        Returns:
+            None
+
+        """
+        TileIndexQueue.deleteQueue(self.nd_proj, endpoint_url=None)
+
+    def delete_tile_error_queue(self):
+        """
+        Delete the current upload queue
+        Returns:
+            None
+
+        """
+        TileErrorQueue.deleteQueue(self.nd_proj, endpoint_url=None)
 
     def delete_ingest_queue(self):
         """
@@ -616,14 +691,16 @@ class IngestManager:
         """
         # Generate credentials for the ingest_job
         upload_queue = self.get_ingest_job_upload_queue(ingest_job)
+        tile_index_queue = None
         ingest_creds = IngestCredentials()
         if ingest_job.ingest_type == IngestJob.TILE_INGEST:
             bucket_name = TileBucket.getBucketName()
+            tile_index_queue = self.get_ingest_job_tile_index_queue(ingest_job)
         elif ingest_job.ingest_type == IngestJob.VOLUMETRIC_INGEST:
             bucket_name = INGEST_BUCKET 
         else:
             raise ValueError('Unknown ingest_type: {}'.format(ingest_job.ingest_type))
-        policy = BossUtil.generate_ingest_policy(ingest_job.id, upload_queue, bucket_name, ingest_type=ingest_job.ingest_type)
+        policy = BossUtil.generate_ingest_policy(ingest_job.id, upload_queue, tile_index_queue, bucket_name, ingest_type=ingest_job.ingest_type)
         ingest_creds.generate_credentials(ingest_job.id, policy.arn)
 
     def remove_ingest_credentials(self, job_id):

--- a/django/bossingest/views.py
+++ b/django/bossingest/views.py
@@ -121,6 +121,9 @@ class IngestJobView(IngestServiceView):
 
             # Start setting up output
             data = {'ingest_job': serializer.data}
+            data['ingest_job']['tile_index_queue'] = None
+            if ingest_job.ingest_type == IngestJob.TILE_INGEST:
+                data['ingest_job']['tile_index_queue'] = ingest_mgmr.get_ingest_job_tile_index_queue().url
 
             if ingest_job.status == 3:
                 # The job has been deleted

--- a/django/bossingest/views.py
+++ b/django/bossingest/views.py
@@ -123,7 +123,7 @@ class IngestJobView(IngestServiceView):
             data = {'ingest_job': serializer.data}
             data['ingest_job']['tile_index_queue'] = None
             if ingest_job.ingest_type == IngestJob.TILE_INGEST:
-                data['ingest_job']['tile_index_queue'] = ingest_mgmr.get_ingest_job_tile_index_queue().url
+                data['ingest_job']['tile_index_queue'] = ingest_mgmr.get_ingest_job_tile_index_queue(ingest_job).url
 
             if ingest_job.status == 3:
                 # The job has been deleted


### PR DESCRIPTION
Adds support for the new tile index and tile error queues that are part of the new ingest design.

Related PRs:
https://github.com/jhuapl-boss/boss-manage/pull/34
https://github.com/jhuapl-boss/ndingest/pull/7
https://github.com/jhuapl-boss/boss-tools/pull/30
https://github.com/jhuapl-boss/ingest-client/pull/20