### PR TITLE
Clear flush queue between tests.

### DIFF
--- a/django/bossspatialdb/test/int_test_cutout_view_uint16.py
+++ b/django/bossspatialdb/test/int_test_cutout_view_uint16.py
@@ -57,3 +57,5 @@ class CutoutViewIntegration16BitTests(CutoutInterfaceViewUint16TestMixin, APITes
         client = redis.StrictRedis(host=self.state_config['cache_state_host'],
                                    port=6379, db=1, decode_responses=False)
         client.flushdb()
+
+        self.layer.clear_flush_queue()

--- a/django/bossspatialdb/test/int_test_cutout_view_uint64.py
+++ b/django/bossspatialdb/test/int_test_cutout_view_uint64.py
@@ -55,3 +55,5 @@ class CutoutViewIntegration64BitTests(CutoutInterfaceViewUint64TestMixin, APITes
         client = redis.StrictRedis(host=self.state_config['cache_state_host'],
                                    port=6379, db=1, decode_responses=False)
         client.flushdb()
+
+        self.layer.clear_flush_queue()

--- a/django/bossspatialdb/test/int_test_cutout_view_uint8.py
+++ b/django/bossspatialdb/test/int_test_cutout_view_uint8.py
@@ -130,5 +130,5 @@ class CutoutViewIntegration8BitTests(APITestCase, CutoutInterfaceViewUint8TestMi
                                    port=6379, db=1, decode_responses=False)
         client.flushdb()
 
-
+        self.layer.clear_flush_queue()
 

--- a/django/bossspatialdb/test/int_test_downsample_view.py
+++ b/django/bossspatialdb/test/int_test_downsample_view.py
@@ -257,5 +257,4 @@ class TestIntegrationDownsampleInterfaceView(DownsampleInterfaceViewMixin, APITe
         self.dbsetup.insert_iso_data()
 
     def tearDown(self):
-        # Stop mocking
-        pass
+        self.layer.clear_flush_queue()


### PR DESCRIPTION
Cutout service integration tests place messages on the flush queue when
they write cuboids using the cutout service.  If the flush lambda fails
during a test, messages from that test will still be in the flush queue.
These messages will likely cause subsequent tests to fail.

Related PR:
https://github.com/jhuapl-boss/spdb/pull/11
