### PR TITLE
Pinned django-guardian at 1.4.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,13 @@ uWSGI==2.0.12
 -e git+http://github.com/jhuapl-boss/drf-oidc-auth.git#egg=drf-oidc-auth
 -e git+http://github.com/jhuapl-boss/django-oidc.git#egg=django-oidc
 -e git+http://github.com/jhuapl-boss/boss-oidc.git#egg=boss-oidc
-django-guardian
+
+# django-guardian 1.5.0 get this error on endpoint when trying to make migrations:
+# File "/usr/local/lib/python3.5/site-packages/guardian/admin.py", line 11, in <module>'}}
+#    from django.urls import reverse'}}
+#    "ImportError: No module named 'django.urls'"}}
+# Pinning at 1.4.9 for now.
+django-guardian==1.4.9
 django-cors-headers
 django-bootstrap-form
 django-redis


### PR DESCRIPTION
django-guardian 1.5.0 fails  to work on the endpoint during /etc/init.d/boss-firstboot during django/manage.py makemigrations.

Pinning django-guardian to 1.4.9 fixed the problem
