### PR TITLE
updated no-cache tests to wait before pulling back down test data.

### DIFF
--- a/django/bossspatialdb/test/cutout_view_uint8.py
+++ b/django/bossspatialdb/test/cutout_view_uint8.py
@@ -27,6 +27,7 @@ from bosscore.error import BossError
 import numpy as np
 import zlib
 import io
+import time
 from PIL import Image
 
 from unittest.mock import patch
@@ -1113,6 +1114,8 @@ class CutoutInterfaceViewUint8TestMixin(object):
 
         # log in user
         force_authenticate(request, user=self.user)
+
+        time.sleep(10)
 
         # Make request
         response = Cutout.as_view()(request, collection='col1', experiment='exp1', channel='channel1',

--- a/django/bosstiles/test/int_test_tiles_view_uint8.py
+++ b/django/bosstiles/test/int_test_tiles_view_uint8.py
@@ -26,6 +26,7 @@ from bosstiles.views import Tile, CutoutTile
 import numpy as np
 import blosc
 import redis
+import time
 
 version = settings.BOSS_VERSION
 
@@ -76,6 +77,8 @@ class ImageViewIntegrationTests(ImageInterfaceViewTestMixin, APITestCase):
         request = factory.get('/' + version + '/image/col1/exp1/channel1/xy/0/400:700/300:800/3/?no-cache=true',
                               Accept='image/png')
         force_authenticate(request, user=self.user)
+
+        time.sleep(10)
 
         # Make request
         response = CutoutTile.as_view()(request, collection='col1', experiment='exp1', channel='channel1',
@@ -135,6 +138,8 @@ class TileViewIntegrationTests(TileInterfaceViewTestMixin, APITestCase):
         request = factory.get('/' + version + '/tile/col1/exp1/channel1/xy/512/0/0/0/5/?no-cache=true',
                               Accept='image/png')
         force_authenticate(request, user=self.user)
+
+        time.sleep(10)
 
         # Make request
         response = Tile.as_view()(request, collection='col1', experiment='exp1', channel='channel1',


### PR DESCRIPTION
tests were failing because data not given time to write back.  Since no cache was being used.  Added a sleep of 10 seconds after write.