### PR TITLE
Django cors headers pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ django-guardian==1.4.9
 # django-cors-headers 2.5.0 has removed support for django 1.8, 1.9 and 1.10.
 #    Using it causes: ImportError: cannot import name 'MiddlewareMixin' in
 #    uwsgi logs and fails to work properly.
-django-cors-headers=2.4.1
+django-cors-headers==2.4.1
 django-bootstrap-form
 django-redis
 git+https://github.com/jhuapl-boss/django-nose2.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,11 @@ uWSGI==2.0.12
 #    "ImportError: No module named 'django.urls'"}}
 # Pinning at 1.4.9 for now.
 django-guardian==1.4.9
-django-cors-headers
+
+# django-cors-headers 2.5.0 has removed support for django 1.8, 1.9 and 1.10.
+#    Using it causes: ImportError: cannot import name 'MiddlewareMixin' in
+#    uwsgi logs and fails to work properly.
+django-cors-headers=2.4.1
 django-bootstrap-form
 django-redis
 git+https://github.com/jhuapl-boss/django-nose2.git


### PR DESCRIPTION
Problem: pip installable module: django-cors-headers version 2.5.0 removed support for Django 1.8, 1.9, and 1.10

Error when using 2.5.0
the removed support can be seen on our endpoints by causing this error in the uswgi/emperor.log
[pid: 1635|app: 0|req: 24/42] 10.0.29.173 () {34 vars in 383 bytes} [Wed Mar  6 20:07:47 2019] GET /ping/ => generated 0 bytes in 1 msecs (HTTP/1.1 500) 0 headers in 0 bytes (1 switches on core 0)
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/site-packages/django/core/handlers/wsgi.py", line 158, in __call__
    self.load_middleware()
  File "/usr/local/lib/python3.5/site-packages/django/core/handlers/base.py", line 51, in load_middleware
    mw_class = import_string(middleware_path)
  File "/usr/local/lib/python3.5/site-packages/django/utils/module_loading.py", line 20, in import_string
    module = import_module(module_path)
  File "/usr/local/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 662, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/usr/local/lib/python3.5/site-packages/corsheaders/middleware.py", line 8, in <module>
    from django.utils.deprecation import MiddlewareMixin
ImportError: cannot import name 'MiddlewareMixin'

The endpoints don't response to api calls.

Solution: 
Pinned django-cors-headers to 2.4.1 
