### PR TITLE
Fix ng button bug

### DIFF
--- a/django/mgmt/static/js/experiments.js
+++ b/django/mgmt/static/js/experiments.js
@@ -3,7 +3,6 @@ function channel_handler(response) {
     var detail_base_url = window.location.href + "/";
     var delete_function = "delete_channel";
     var delete_base_url = API_ROOT + "collection/" + resources[0] + "/experiment/" + resources[1] + "/channel/";
-    var raw_host = window.location.host.split["."];
     var neuroglancer_url = "https://neuroglancer.theboss.io/#!{'layers':{'" + resources[1] + "':{'source':'boss://https://" + window.location.host + "/" + resources[0] + "/" + resources[1] + "/";
 
     return channel_resource_formatter(response, detail_base_url, delete_function, delete_base_url, neuroglancer_url);

--- a/django/mgmt/static/js/experiments.js
+++ b/django/mgmt/static/js/experiments.js
@@ -3,7 +3,8 @@ function channel_handler(response) {
     var detail_base_url = window.location.href + "/";
     var delete_function = "delete_channel";
     var delete_base_url = API_ROOT + "collection/" + resources[0] + "/experiment/" + resources[1] + "/channel/";
-    var neuroglancer_url = "https://neuroglancer.theboss.io/#!{'layers':{'" + resources[1] + "':{'source':'boss://https://api.theboss.io/" + resources[0] + "/" + resources[1] + "/";
+    var raw_host = window.location.host.split["."];
+    var neuroglancer_url = "https://neuroglancer.theboss.io/#!{'layers':{'" + resources[1] + "':{'source':'boss://https://" + window.location.host + "/" + resources[0] + "/" + resources[1] + "/";
 
     return channel_resource_formatter(response, detail_base_url, delete_function, delete_base_url, neuroglancer_url);
 }


### PR DESCRIPTION
Remove hardcoded boss source.
Neuroglancer button source should point to window.location.host. 

We should reconsider later if we want to also have a dynamic neuroglancer link. We discussed making this another variable in thew bosslet config file. Something to keep in mind for the future. 