### PR TITLE
Usage throttling

### DIFF
--- a/django/boss/settings/base.py
+++ b/django/boss/settings/base.py
@@ -151,6 +151,9 @@ BOSS_VERSION = 'v1'
 # Maximum number of bytes in an uncompressed matrix supported by the Cutout Service
 CUTOUT_MAX_SIZE = 520 * 1048576
 
+# Maximum number of pixels that non-privileged users can ingest (200 x 200 x 200 cubes)
+INGEST_MAX_SIZE = (200 * 512) * (200 * 512) * (200 * 16)
+
 # Allow all cross site origins
 CORS_ORIGIN_ALLOW_ALL = True
 

--- a/django/boss/throttling.py
+++ b/django/boss/throttling.py
@@ -43,6 +43,8 @@ class RedisMetrics(object):
         resp = self.conn.get(key)
         if resp is None:
             resp = 0
+        else:
+            resp = int(resp.decode('utf8'))
         return resp
 
     def add_metric_cost(self, obj, val):
@@ -50,7 +52,7 @@ class RedisMetrics(object):
             return
 
         key = "{}_metric".format(obj)
-        self.conn.incrby(key, val)
+        self.conn.incrby(key, int(val))
 
 class BossThrottle(object):
     user_error_detail = _("User is throttled. Expected available tomorrow.")

--- a/django/boss/throttling.py
+++ b/django/boss/throttling.py
@@ -1,0 +1,106 @@
+# Copyright 2019 The Johns Hopkins University Applied Physics Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rest_framework.exceptions import Throttled
+
+from django.utils.translation import ugettext_lazy as _
+from django.conf import settings as django_settings
+
+import bossutils
+
+import redis
+
+class RedisMetrics(object):
+    # NOTE: If there is no throttling redis instance the other methods don't do anything
+    # NOTE: External process will reset values to zero when the window expires
+    # {obj}_metric = current_cost_in_window
+
+    def __init__(self):
+        boss_config = bossutils.configuration.BossConfig()
+        if len(boss_config['aws']['cache-throttle']) > 0:
+            self.conn = redis.StrictRedis(boss_config['aws']['cache-throttle'],
+                                          6379,
+                                          boss_config['aws']['cache-throttle-db'])
+        else:
+            self.conn = None
+
+    def get_metric(self, obj):
+        if self.conn is None:
+            return 0
+
+        key = "{}_metric".format(obj)
+        resp = self.conn.get(key)
+        if resp is None:
+            resp = 0
+        return resp
+
+    def add_metric_cost(self, obj, val):
+        if self.conn is None:
+            return
+
+        key = "{}_metric".format(obj)
+        self.conn.incrby(key, val)
+
+class BossThrottle(object):
+    user_error_detail = _("User is throttled. Expected available tomorrow.")
+    api_error_detail = _("API is throttled. Expected available tomorrow.")
+    system_error_detail = _("System is throttled. Expected available tomorrow.")
+
+    USER_DEFAULT_MAX = 100 * 1024 * 1024 # 100 MB / day
+    API_DEFAULT_MAX = 1 * 1024 * 1024 * 1024 # 1 GB / day
+    SYSTEM_DEFAULT_MAX = 10 * 1024 * 1024 * 1024 # 10 GB / day
+
+    # NOTE: Check methods don't add the new cost before checking so as to
+    #       still allow an API call that will exceed the limit, in case the
+    #       limit would disallow most API calls
+
+    # TODO: Figure out how to have more dynamic rules
+
+    def __init__(self):
+        self.data = RedisMetrics()
+
+    def error(self, msg):
+        raise Throttled(detail = msg)
+
+    def check(self, api, user, cost):
+        self.check_user(user, cost)
+        self.check_api(api, cost)
+        self.check_system(cost)
+
+    def check_user(self, user, cost)
+        current = self.data.get_metric(user)
+        max = self.USER_DEFAULT_MAX
+
+        if current > max:
+            self.error(self.user_error_detail)
+
+        self.data.add_metric_cost(user, cost)
+
+    def check_api(self, api, cost)
+        current = self.data.get_metric(api)
+        max = self.API_DEFAULT_MAX
+
+        if current > max:
+            self.error(self.api_error_detail)
+
+        self.data.add_metric_cost(api, cost)
+
+    def check_system(self, cost)
+        current = self.data.get_metric('system')
+        max = self.SYSTEM_DEFAULT_MAX
+
+        if current > max:
+            self.error(self.system_error_detail)
+
+        self.data.add_metric_cost('system', cost)

--- a/django/boss/throttling.py
+++ b/django/boss/throttling.py
@@ -78,7 +78,7 @@ class BossThrottle(object):
         self.check_api(api, cost)
         self.check_system(cost)
 
-    def check_user(self, user, cost)
+    def check_user(self, user, cost):
         current = self.data.get_metric(user)
         max = self.USER_DEFAULT_MAX
 
@@ -87,7 +87,7 @@ class BossThrottle(object):
 
         self.data.add_metric_cost(user, cost)
 
-    def check_api(self, api, cost)
+    def check_api(self, api, cost):
         current = self.data.get_metric(api)
         max = self.API_DEFAULT_MAX
 
@@ -96,7 +96,7 @@ class BossThrottle(object):
 
         self.data.add_metric_cost(api, cost)
 
-    def check_system(self, cost)
+    def check_system(self, cost):
         current = self.data.get_metric('system')
         max = self.SYSTEM_DEFAULT_MAX
 

--- a/django/boss/throttling.py
+++ b/django/boss/throttling.py
@@ -23,6 +23,20 @@ import redis
 import boto3
 
 def parse_limit(val):
+    """Convert a textual representation of a number of bytes into an integer
+
+    NOTE: If val is None then None is returned
+
+    Args:
+        val (str): number of bytes
+                   Format: <num><unit> where
+                           <num> - is a float
+                           <unit> is one of K, M, G, T, P for
+                           kilobytes, megabytes, gigabytes, terabytes, petabytes
+
+    Returns:
+        int: Number of bytes
+    """
     if val is None:
         return None
 
@@ -41,6 +55,14 @@ class RedisMetrics(object):
     # NOTE: If there is no throttling redis instance the other methods don't do anything
     # NOTE: External process will reset values to zero when the window expires
     # {obj}_metric = current_cost_in_window
+    """
+    Object for interacting with a Redis instance storing metric data
+
+    NOTE: If there is no throttling Redis instance the methods don't do anything
+    NOTE: An external process will reset the metrics to zero when the time window expires
+
+    Redis data format: {obj}_metric = current_usage_in_window
+    """
 
     def __init__(self):
         boss_config = bossutils.configuration.BossConfig()
@@ -52,6 +74,14 @@ class RedisMetrics(object):
             self.conn = None
 
     def get_metric(self, obj):
+        """Get the current metric value for the given object
+
+        Args:
+            obj (str): Name of the object for which to get the current metric value
+
+        Returns:
+            int: Current metric value or zero if there is no Redis instance or no Redis key
+        """
         if self.conn is None:
             return 0
 
@@ -64,6 +94,15 @@ class RedisMetrics(object):
         return resp
 
     def add_metric_cost(self, obj, val):
+        """Increment the current metric value by the given value for the given object
+
+        NOTE: If there is no Redis instance this method doesn't do anything
+
+        Args:
+            obj (str): Name of the object for which to increment the current metric value
+            val (float|int): Value by which to increase the current metric value
+                             NOTE: Value will be convered into an integer
+        """
         if self.conn is None:
             return
 
@@ -71,6 +110,10 @@ class RedisMetrics(object):
         self.conn.incrby(key, int(val))
 
 class MetricLimits(object):
+    """Object for reading metric limits from Vault
+
+    NOTE: Values are read once from Vault on initialization
+    """
     def __init__(self):
         vault = bossutils.vault.Vault()
         data = vault.read('secret/endpoint/throttle', 'config')
@@ -82,12 +125,37 @@ class MetricLimits(object):
         self.groups = data.get('groups')
 
     def lookup_system(self):
+        """Return the current metric limit for the entire system
+
+        Returns:
+            int or None
+        """
         return parse_limit(self.system)
 
     def lookup_api(self, api):
+        """Return the current metric limit for the given API
+
+        Args:
+            api (str): Name of the API to get the metric limit for
+
+        Returns:
+            int or None
+        """
         return parse_limit(self.apis.get(api))
 
     def lookup_user(self, user):
+        """Return the current metric limit for the given user
+
+        A user's metric limit can either be the value given specifically
+        to the user or it can be the maximum metric limit for all of the
+        groups that the user is a part of.
+
+        Args:
+            user (User): Django user object to get the metric limit for
+
+        Returns:
+            int or None
+        """
         # User specific settings will override any group based limits
         if user.username in self.users:
             return parse_limit(self.users[user.username])
@@ -103,13 +171,21 @@ class MetricLimits(object):
             return max(limits)
 
 class BossThrottle(object):
+    """Object for checking if a given API call is throttled
+
+    NOTE: The check_* methods don't add the new cost before checking
+          if the current call is throttled, so as to still allow an API
+          call that will exceed the limit, in case the limit would
+          disallow most API calls
+
+    Attributes:
+        user_error_detail (str): Error message if the user is throttled
+        api_error_detail (str): Error message if the API is throttled
+        system_error_detail (str): Error message if the whole system is throttled
+    """
     user_error_detail = _("User is throttled. Expected available tomorrow.")
     api_error_detail = _("API is throttled. Expected available tomorrow.")
     system_error_detail = _("System is throttled. Expected available tomorrow.")
-
-    # NOTE: Check methods don't add the new cost before checking so as to
-    #       still allow an API call that will exceed the limit, in case the
-    #       limit would disallow most API calls
 
     def __init__(self):
         self.data = RedisMetrics()
@@ -120,6 +196,20 @@ class BossThrottle(object):
         self.fqdn = boss_config['system']['fqdn']
 
     def error(self, user=None, api=None, system=None, details=None):
+        """Method for notifying admins and raising a Throttle exception
+
+        Notifications are send to the Production Mailing List SNS topic
+
+        Args:
+            user (optional[str]): Name of the user, if the user is throttled
+            api (optional[str]): Name of the API, if the API is throttled
+            system (optional[bool]): If the system is throttled
+            details (dict): Information about the API call that will be included
+                            in the notification to the administrators
+
+        Raises:
+            Throttle: Exception with generic information on why the call was throttled
+        """
         if user:
             ex_msg = self.user_error_detail
             sns_msg = "Throttling user '{}': {}".format(user, json.dumps(details))
@@ -138,6 +228,18 @@ class BossThrottle(object):
         raise Throttled(detail = ex_msg)
 
     def check(self, api, user, cost):
+        """Check to see if the given API call is throttled
+
+        This is the main BossThrottle method and will call the other check_* methods
+
+        Args:
+            api (str): Name of the API call being made
+            user (User): Django user making the request
+            cost (float|int): Cost of the API call being made
+
+        Raises:
+            Throttle: If the call is throttled
+        """
         details = {'api': api, 'user': user, 'cost': cost, 'fqdn': self.fqdn}
 
         self.check_user(user, cost, details)
@@ -145,6 +247,20 @@ class BossThrottle(object):
         self.check_system(cost, details)
 
     def check_user(self, user, cost, details):
+        """Check to see if the user is currently throttled
+
+        NOTE: This method will increment the current metric value by cost
+              if not throttled
+
+        Args:
+            user (User): Django user making the request
+            cost (float|int): Cost of the API call being made
+            details (dict): General information about the call to be
+                            used when notifying administrators
+
+        Raises:
+            Throttle: If the user is throttled
+        """
         current = self.data.get_metric(user.username)
         max = self.limits.lookup_user(user)
 
@@ -159,6 +275,20 @@ class BossThrottle(object):
         self.data.add_metric_cost(user.username, cost)
 
     def check_api(self, api, cost, details):
+        """Check to see if the API is currently throttled
+
+        NOTE: This method will increment the current metric value by cost
+              if not throttled
+
+        Args:
+            api (str): Name of the API call being made
+            cost (float|int): Cost of the API call being made
+            details (dict): General information about the call to be
+                            used when notifying administrators
+
+        Raises:
+            Throttle: If the API is throttled
+        """
         current = self.data.get_metric(api)
         max = self.limits.lookup_api(api)
 
@@ -173,6 +303,19 @@ class BossThrottle(object):
         self.data.add_metric_cost(api, cost)
 
     def check_system(self, cost, details):
+        """Check to see if the System is currently throttled
+
+        NOTE: This method will increment the current metric value by cost
+              if not throttled
+
+        Args:
+            cost (float|int): Cost of the API call being made
+            details (dict): General information about the call to be
+                            used when notifying administrators
+
+        Raises:
+            Throttle: If the system is throttled
+        """
         current = self.data.get_metric('system')
         max = self.limits.lookup_system()
 

--- a/django/boss/throttling.py
+++ b/django/boss/throttling.py
@@ -117,6 +117,7 @@ class BossThrottle(object):
 
         boss_config = bossutils.configuration.BossConfig()
         self.topic = boss_config['aws']['prod_mailing_list']
+        self.fqdn = boss_config['system']['fqdn']
 
     def error(self, user=None, api=None, system=None, details=None):
         if user:
@@ -137,7 +138,7 @@ class BossThrottle(object):
         raise Throttled(detail = ex_msg)
 
     def check(self, api, user, cost):
-        details = {'api': api, 'user': user, 'cost': cost}
+        details = {'api': api, 'user': user, 'cost': cost, 'fqdn': self.fqdn}
 
         self.check_user(user, cost, details)
         self.check_api(api, cost, details)

--- a/django/bosscore/constants.py
+++ b/django/bosscore/constants.py
@@ -23,3 +23,5 @@ ADMIN_GRP = 'admin'
 # Public group
 PUBLIC_GRP = 'bosspublic'
 
+# Large ingest group
+INGEST_GRP = 'bossingest'

--- a/django/bosscore/renderer_helper.py
+++ b/django/bosscore/renderer_helper.py
@@ -103,7 +103,7 @@ def check_for_429(fcn):
         # Have a response, check for 429.
         if renderer_context['response'].status_code == 429:
             renderer_context['response']['Content-Type'] = 'application/json'
-            err_msg = {"status": 429, "message": args[1],
+            err_msg = {"status": 429, "message": args[1]['detail'],
                        "code": ErrorCodes.ACCESS_DENIED_UNKNOWN}
             jr = JSONRenderer()
             return jr.render(err_msg, 'application/json', renderer_context)

--- a/django/bosscore/renderer_helper.py
+++ b/django/bosscore/renderer_helper.py
@@ -16,7 +16,13 @@ from bosscore.error import ErrorCodes
 from rest_framework.renderers import JSONRenderer
 
 def extract_context(*args, **kwargs):
-    # renderer_context is the 4th argument if not specified by keyword.
+    """General method for extracting the renderer_context
+
+    Used by decorators to extract the renderer_context from the
+    arguments of the method they are wrapping.
+
+    The renderer_context is the 4th argument if not specified by keyword
+    """
     if len(args) < 4 and kwargs is None:
         return None
 

--- a/django/bosscore/renderer_helper.py
+++ b/django/bosscore/renderer_helper.py
@@ -15,6 +15,26 @@
 from bosscore.error import ErrorCodes
 from rest_framework.renderers import JSONRenderer
 
+def extract_context(*args, **kwargs):
+    # renderer_context is the 4th argument if not specified by keyword.
+    if len(args) < 4 and kwargs is None:
+        return None
+
+    renderer_context = None
+    if len(args) >= 4:
+        renderer_context = args[3]
+    elif kwargs is not None and 'renderer_context' in kwargs:
+        renderer_context = kwargs['renderer_context']
+
+    if renderer_context is None:
+        return None
+
+    # Check for presense of a Response object.
+    if 'response' not in renderer_context:
+        return None
+
+    return renderer_context
+
 def check_for_403(fcn):
     """Decorator to check renderer_context for a 403 response.
 
@@ -36,21 +56,8 @@ def check_for_403(fcn):
             (BaseRenderer)
         """
 
-        # renderer_context is the 4th argument if not specified by keyword.
-        if len(args) < 4 and kwargs is None:
-            return fcn(*args, **kwargs)
-
-        renderer_context = None
-        if len(args) >= 4:
-            renderer_context = args[3]
-        elif kwargs is not None and 'renderer_context' in kwargs:
-            renderer_context = kwargs['renderer_context']
-
+        renderer_context = extract_context(*args, **kwargs)
         if renderer_context is None:
-            return fcn(*args, **kwargs)
-
-        # Check for presense of a Response object.
-        if 'response' not in renderer_context:
             return fcn(*args, **kwargs)
 
         # Have a response, check for 403.
@@ -60,6 +67,43 @@ def check_for_403(fcn):
             obj.media_type = 'application/json'
             obj.format = 'json'
             err_msg = {"status": 403, "message": "Access denied, are you logged in?",
+                       "code": ErrorCodes.ACCESS_DENIED_UNKNOWN}
+            jr = JSONRenderer()
+            return jr.render(err_msg, 'application/json', renderer_context)
+
+        return fcn(*args, **kwargs)
+
+    return wrapper
+
+def check_for_429(fcn):
+    """Decorator to check renderer_context for a 429 (Throttled) response.
+
+    Args:
+        fcn (function): A custom BaseRenderer.render() implementation..
+
+    Returns:
+        (function): Wraps given function with one that checks for a 429 status.
+    """
+
+    def wrapper(*args, **kwargs):
+        """Return a JSON response if a 429 found.
+
+        Executes the custom renderer if no 429 status code found.
+
+        Args:
+
+        Returns:
+            (BaseRenderer)
+        """
+
+        renderer_context = extract_context(*args, **kwargs)
+        if renderer_context is None:
+            return fcn(*args, **kwargs)
+
+        # Have a response, check for 429.
+        if renderer_context['response'].status_code == 429:
+            renderer_context['response']['Content-Type'] = 'application/json'
+            err_msg = {"status": 429, "message": args[1],
                        "code": ErrorCodes.ACCESS_DENIED_UNKNOWN}
             jr = JSONRenderer()
             return jr.render(err_msg, 'application/json', renderer_context)

--- a/django/bossingest/views.py
+++ b/django/bossingest/views.py
@@ -233,7 +233,6 @@ class IngestJobView(IngestServiceView):
         database = ingest_config_data['database']
 
         # Check that only permitted users are creating extra large ingests
-        large_ingest = 100000 * 100000 * 3000 # ~ 200 x 200 x 200 cubes
         try:
             group = Group.objects.get(name=INGEST_GRP)
             in_large_ingest_group = group.user_set.filter(id=request.user.id).exists()
@@ -244,7 +243,7 @@ class IngestJobView(IngestServiceView):
            ((extent['x'][1] - extent['x'][0]) * \
             (extent['y'][1] - extent['y'][0]) * \
             (extent['z'][1] - extent['z'][0]) * \
-            (extent['t'][1] - extent['t'][0]) > large_ingest):
+            (extent['t'][1] - extent['t'][0]) > settings.INGEST_MAX_SIZE):
             return BossHTTPError("Large ingests require special permission to create. Contact system administrator.", ErrorCodes.INVALID_STATE)
 
         # Calculate the cost of the ingest

--- a/django/bossingest/views.py
+++ b/django/bossingest/views.py
@@ -14,7 +14,7 @@
 
 from django.shortcuts import render
 from django.conf import settings
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, Group
 from django.db.models import Q
 
 from rest_framework.views import APIView
@@ -22,6 +22,7 @@ from rest_framework.response import Response
 from rest_framework import status
 from rest_framework import generics
 
+from bosscore.constants import INGEST_GRP
 from bosscore.error import BossError, ErrorCodes, BossHTTPError
 from bossingest.ingest_manager import IngestManager, INGEST_BUCKET
 from bossingest.serializers import IngestJobListSerializer
@@ -231,6 +232,22 @@ class IngestJobView(IngestServiceView):
         tile_size = ingest_config_data['ingest_job']['tile_size']
         database = ingest_config_data['database']
 
+        # Check that only permitted users are creating extra large ingests
+        large_ingest = 100000 * 100000 * 3000 # ~ 200 x 200 x 200 cubes
+        try:
+            group = Group.objects.get(name=INGEST_GRP)
+            in_large_ingest_group = group.user_set.filter(id=request.user.id).exists()
+        except Group.DoesNotExist:
+            # Just in case the group has not been created yet
+            in_large_ingest_group = False
+        if (not in_large_ingest_group) and \
+           ((extent['x'][1] - extent['x'][0]) * \
+            (extent['y'][1] - extent['y'][0]) * \
+            (extent['z'][1] - extent['z'][0]) * \
+            (extent['t'][1] - extent['t'][0]) > large_ingest):
+            return BossHTTPError("Large ingests require special permission to create. Contact system administrator.", ErrorCodes.INVALID_STATE)
+
+        # Calculate the cost of the ingest
         cost = ( ((extent['x'][1] - extent['x'][0]) / tile_size['x'])
                * ((extent['y'][1] - extent['y'][0]) / tile_size['y'])
                * ((extent['z'][1] - extent['z'][0]) / tile_size['z'])

--- a/django/bossspatialdb/renderers.py
+++ b/django/bossspatialdb/renderers.py
@@ -20,7 +20,7 @@ import zlib
 import io
 from PIL import Image
 
-from bosscore.renderer_helper import check_for_403
+from bosscore.renderer_helper import check_for_403, check_for_429
 
 class BloscPythonRenderer(renderers.BaseRenderer):
     """ A DRF renderer for a blosc encoded cube of data using the numpy interface

--- a/django/bossspatialdb/renderers.py
+++ b/django/bossspatialdb/renderers.py
@@ -33,6 +33,7 @@ class BloscPythonRenderer(renderers.BaseRenderer):
     render_style = 'binary'
 
     @check_for_403
+    @check_for_429
     def render(self, data, media_type=None, renderer_context=None):
 
         if not data["data"].data.flags['C_CONTIGUOUS']:
@@ -55,6 +56,7 @@ class BloscRenderer(renderers.BaseRenderer):
     render_style = 'binary'
 
     @check_for_403
+    @check_for_429
     def render(self, data, media_type=None, renderer_context=None):
 
         if renderer_context['response'].status_code == 403:
@@ -88,6 +90,7 @@ class NpygzRenderer(renderers.BaseRenderer):
     render_style = 'binary'
 
     @check_for_403
+    @check_for_429
     def render(self, data, media_type=None, renderer_context=None):
 
         if not data["data"].data.flags['C_CONTIGUOUS']:
@@ -120,6 +123,7 @@ class JpegRenderer(renderers.BaseRenderer):
     render_style = 'binary'
 
     @check_for_403
+    @check_for_429
     def render(self, data, media_type=None, renderer_context=None):
 
         # Return data, squeezing time dimension as this only works with 3D data

--- a/django/bossspatialdb/views.py
+++ b/django/bossspatialdb/views.py
@@ -133,7 +133,7 @@ class Cutout(APIView):
                ) # Calculating the number of bytes
 
         BossThrottle().check('cutout_egress',
-                             request.user.username,
+                             request.user,
                              cost)
 
         boss_config = bossutils.configuration.BossConfig()
@@ -244,7 +244,7 @@ class Cutout(APIView):
                ) # Calculating the number of bytes
 
         BossThrottle().check('cutout_ingress',
-                             request.user.username,
+                             request.user,
                              cost)
 
         boss_config = bossutils.configuration.BossConfig()

--- a/django/bossspatialdb/views.py
+++ b/django/bossspatialdb/views.py
@@ -30,6 +30,7 @@ from bosscore.error import BossError, BossHTTPError, BossParserError, ErrorCodes
 from bosscore.models import Channel
 
 from boss import utils
+from boss.throttling import BossThrottle
 
 from spdb.spatialdb.spatialdb import SpatialDB, CUBOIDSIZE
 from spdb.spatialdb.rediskvio import RedisKVIO
@@ -130,6 +131,10 @@ class Cutout(APIView):
                * self.bit_depth
                / 8
                ) # Calculating the number of bytes
+
+        BossThrottle().check('cutout_egress',
+                             request.user.username,
+                             cost)
 
         boss_config = bossutils.configuration.BossConfig()
         dimensions = [
@@ -237,6 +242,10 @@ class Cutout(APIView):
                * resource.get_bit_depth()
                / 8
                ) # Calculating the number of bytes
+
+        BossThrottle().check('cutout_ingress',
+                             request.user.username,
+                             cost)
 
         boss_config = bossutils.configuration.BossConfig()
         dimensions = [

--- a/django/bosstiles/renderers.py
+++ b/django/bosstiles/renderers.py
@@ -26,6 +26,7 @@ class PNGRenderer(renderers.BaseRenderer):
     render_style = 'binary'
 
     @check_for_403
+    @check_for_429
     def render(self, data, media_type=None, renderer_context=None):
         file_obj = io.BytesIO()
         data.save(file_obj, "PNG")
@@ -42,6 +43,7 @@ class JPEGRenderer(renderers.BaseRenderer):
     render_style = 'binary'
 
     @check_for_403
+    @check_for_429
     def render(self, data, media_type=None, renderer_context=None):
         file_obj = io.BytesIO()
         data.save(file_obj, "JPEG")

--- a/django/bosstiles/renderers.py
+++ b/django/bosstiles/renderers.py
@@ -14,7 +14,7 @@
 import io
 from rest_framework import renderers
 from rest_framework.renderers import JSONRenderer
-from bosscore.renderer_helper import check_for_403
+from bosscore.renderer_helper import check_for_403, check_for_429
 
 
 class PNGRenderer(renderers.BaseRenderer):

--- a/django/bosstiles/views.py
+++ b/django/bosstiles/views.py
@@ -17,6 +17,7 @@ from rest_framework.permissions import IsAuthenticated
 from django.conf import settings
 
 from boss import utils
+from boss.throttling import BossThrottle
 from bosscore.request import BossRequest
 from bosscore.error import BossError, BossHTTPError, ErrorCodes
 
@@ -100,6 +101,10 @@ class CutoutTile(APIView):
                * self.bit_depth
                / 8
                ) # Calculating the number of bytes
+
+        BossThrottle().check('image_egress',
+                             request.user.username,
+                             cost)
 
         boss_config = bossutils.configuration.BossConfig()
         dimensions = [
@@ -229,6 +234,10 @@ class Tile(APIView):
                * self.bit_depth
                / 8
                ) # Calculating the number of bytes
+
+        BossThrottle().check('tile_egress',
+                             request.user.username,
+                             cost)
 
         boss_config = bossutils.configuration.BossConfig()
         dimensions = [

--- a/django/bosstiles/views.py
+++ b/django/bosstiles/views.py
@@ -103,7 +103,7 @@ class CutoutTile(APIView):
                ) # Calculating the number of bytes
 
         BossThrottle().check('image_egress',
-                             request.user.username,
+                             request.user,
                              cost)
 
         boss_config = bossutils.configuration.BossConfig()
@@ -236,7 +236,7 @@ class Tile(APIView):
                ) # Calculating the number of bytes
 
         BossThrottle().check('tile_egress',
-                             request.user.username,
+                             request.user,
                              cost)
 
         boss_config = bossutils.configuration.BossConfig()


### PR DESCRIPTION
Added a check to the 4 main APIs that move data in and out of the system to make sure that the system / API / user is not exceeding a soft threshold for the amount of data to allow per day. Live metrics are stored in a new redis instance (See PR jhuapl-boss/boss-manage#67 for details).

The threshold data is loaded fresh from Vault for each check, allowing for dynamic configuration of the thresholds based on the Boss scenario that is deployed. (We could cache the Vault response for improved performance).

The current request's cost is not added to the comparison so that if the limits are set really low that the user is still able to make at least one request for data (this is what I mean about soft threshold). (We could make these hard thresholds if we want to be more strict).

The current throttling algorithm logic is to use a `X bytes / day` model where the system, API, and user all have their own limit for the total number of bytes of data they can work with per day. The redis stored metrics will be reset daily by a lambda that just deletes all of the keys in the redis instance.