### PR TITLE
Update use of base resolution.

### DIFF
--- a/django/bosscore/request.py
+++ b/django/bosscore/request.py
@@ -290,7 +290,7 @@ class BossRequest:
 
         # Bounding box is only valid for annotation channels
         if self.channel.type != 'annotation':
-            raise BossError("The channel in request has type {}. Can only reserve IDs for annotation channels"
+            raise BossError("The channel in request has type {}. Can only perform bounding box operations on annotation channels"
                             .format(self.channel.type), ErrorCodes.DATATYPE_NOT_SUPPORTED)
 
         # TODO : validate the object id
@@ -300,13 +300,25 @@ class BossRequest:
             raise BossError("The id of the object {} is not a valid int".format(self.bossrequest['id']),
                             ErrorCodes.TYPE_ERROR)
 
+        self.validate_resolution()
+
+    def validate_resolution(self):
+        """
+        Ensure requested resolution is between channel's base resolution and the base
+        resolution + the experiment's number of hierarchy levels
+
+        Raises:
+            (BossError): if resolution invalid
+        """
         try:
+            base_res = self.channel.base_resolution
             # validate the resolution
-            if int(self.bossrequest['resolution']) in range(0, self.experiment.num_hierarchy_levels):
+            if int(self.bossrequest['resolution']) in range(base_res, base_res + self.experiment.num_hierarchy_levels):
                 self.resolution = int(self.bossrequest['resolution'])
             else:
-                raise BossError("Invalid resolution {}. The resolution has to be within 0 and {}".
-                                format(self.bossrequest['resolution'],self.experiment.num_hierarchy_levels),
+                raise BossError("Invalid resolution {}. The resolution has to be within {} and {}".
+                                format(self.bossrequest['resolution'], base_res,
+                                base_res + self.experiment.num_hierarchy_levels),
                                 ErrorCodes.TYPE_ERROR)
         except (TypeError, ValueError):
             raise BossError("Type error in resolution {}".format(self.bossrequest['resolution']), ErrorCodes.TYPE_ERROR)
@@ -347,12 +359,7 @@ class BossRequest:
 
         """
         try:
-            # validate the resolution
-            if int(resolution) in range(0, self.experiment.num_hierarchy_levels):
-                self.resolution = int(resolution)
-            else:
-                raise BossError("Invalid resolution {} in cutout args. The resolution has to be between 0 and {}".
-                                format(resolution, self.experiment.num_hierarchy_levels), ErrorCodes.INVALID_CUTOUT_ARGS)
+            self.validate_resolution()
 
             # TODO --- Get offset for that resolution. Reading from  coordinate frame right now, This is WRONG
 
@@ -397,8 +404,7 @@ class BossRequest:
 
         try:
 
-            if int(resolution) in range(0, self.experiment.num_hierarchy_levels):
-                self.resolution = int(resolution)
+            self.validate_resolution()
 
             # TODO --- Get offset for that resolution. Reading from  coordinate frame right now, This is WRONG
 
@@ -468,8 +474,7 @@ class BossRequest:
             y_idx = int(y_idx)
             z_idx = int(z_idx)
 
-            if int(resolution) in range(0, self.experiment.num_hierarchy_levels):
-                self.resolution = int(resolution)
+            self.validate_resolution()
 
             # TODO --- Get offset for that resolution. Reading from  coordinate frame right now, This is WRONG
 

--- a/django/bosscore/serializers.py
+++ b/django/bosscore/serializers.py
@@ -100,20 +100,28 @@ class ChannelSerializer(serializers.ModelSerializer):
         # Get the experiment
         exp = data.get('experiment')
         num_time_samples = exp.num_time_samples
-        num_hierarchy_levels = exp.num_hierarchy_levels
+        #num_hierarchy_levels = exp.num_hierarchy_levels
 
         default_time_sample = data.get('default_time_sample', None)
-        base_resolution = data.get('base_resolution', None)
+        #base_resolution = data.get('base_resolution', None)
 
         # Validate that default_time_step is less than the num_time_samples
         if default_time_sample is not None and default_time_sample >= num_time_samples:
             errors['default_time_sample'] = 'Ensure this value is less that the experiments num_time_samples {}.'\
                 .format(num_time_samples)
 
-        # Validate that base_Resolution is less than the num_hierarchy_levels
+        # Validate that base_resolution is less than the num_hierarchy_levels
+        # We no longer check this because we may delete some resolutions to
+        # reduce storage costs.  When we do this, we change num_hierarchy_levels
+        # after the fact.  After doing this, it's possible that base resolution
+        # is greater than the num_hierarchy_levels.  When viewing with
+        # Neuroglancer, we allow it to request resolutions in
+        # range(base_resolution, base_resolution + num_hierarchy_levels).
+        """
         if base_resolution is not None and base_resolution >= num_hierarchy_levels:
             errors['base_resolution'] = 'Ensure this value is less that the experiments maximum number of ' \
                                         'hierarchy levels {}.'.format(num_hierarchy_levels)
+        """
 
         if len(errors):
             raise serializers.ValidationError(errors)

--- a/django/bosscore/test/setup_db.py
+++ b/django/bosscore/test/setup_db.py
@@ -27,6 +27,17 @@ from spdb.spatialdb.test.setup import AWSSetupLayer
 test_user = 'testuser'
 test_group = 'testuser-primary'
 
+# Used for testing proper handling of channel with non-zero base resolution.
+BASE_RESOLUTION = 2
+NUM_HIERARCHY_LEVELS = 7
+
+# Experiment names used by insert_test_data().
+EXP1 = 'exp1'
+EXP22 = 'exp22'
+EXP_BASE_RES = 'exp-base-res-test'
+TEST_DATA_EXPERIMENTS = [EXP1, EXP22, EXP_BASE_RES]
+
+CHAN_BASE_RES = 'chan-with-base-res'
 
 class SetupTestDB:
     def __init__(self):
@@ -96,13 +107,15 @@ class SetupTestDB:
 
         self.add_coordinate_frame('cf1', 'Description for cf1', 0, 1000, 0, 1000, 0, 1000, 4, 4, 4)
         
-        self.add_experiment('col1', 'exp1', 'cf1', 10, 10, 1)
-        self.add_experiment('col1', 'exp22', 'cf1', 10, 500, 1)
+        self.add_experiment('col1', EXP1, 'cf1', NUM_HIERARCHY_LEVELS, 10, 1)
+        self.add_experiment('col1', EXP22, 'cf1', NUM_HIERARCHY_LEVELS, 500, 1)
+        self.add_experiment('col1', EXP_BASE_RES, 'cf1', NUM_HIERARCHY_LEVELS, 10, 1)
 
-        self.add_channel('col1', 'exp1', 'channel1', 0, 0, 'uint8', 'image')
-        self.add_channel('col1', 'exp1', 'channel2', 0, 0, 'uint8', 'image')
-        self.add_channel('col1', 'exp1', 'channel3', 0, 0, 'uint64', 'annotation', ['channel1'])
-        self.add_channel('col1', 'exp1', 'layer1', 0, 0, 'uint64', 'annotation', ['channel1'])
+        self.add_channel('col1', EXP1, 'channel1', 0, 0, 'uint8', 'image')
+        self.add_channel('col1', EXP1, 'channel2', 0, 0, 'uint8', 'image')
+        self.add_channel('col1', EXP1, 'channel3', 0, 0, 'uint64', 'annotation', ['channel1'])
+        self.add_channel('col1', EXP_BASE_RES, CHAN_BASE_RES, 0, BASE_RESOLUTION, 'uint8', 'image')
+        self.add_channel('col1', EXP1, 'layer1', 0, 0, 'uint64', 'annotation', ['channel1'])
 
     def insert_lookup_test_data(self):
         """

--- a/django/bosscore/test/test_resource_views.py
+++ b/django/bosscore/test/test_resource_views.py
@@ -14,7 +14,7 @@
 
 from rest_framework.test import APITestCase
 from django.conf import settings
-from .setup_db import SetupTestDB
+from .setup_db import SetupTestDB, TEST_DATA_EXPERIMENTS
 
 version = settings.BOSS_VERSION
 
@@ -487,7 +487,7 @@ class ResourceViewsExperimentTests(APITestCase):
         # Get an existing collection
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['experiments'][0], 'exp1')
+        self.assertCountEqual(response.data['experiments'], TEST_DATA_EXPERIMENTS)
 
 
 class ResourceViewsCoordinateTests(APITestCase):
@@ -760,28 +760,6 @@ class ResourceViewsChannelTests(APITestCase):
         # Post a new channel
         url = '/' + version + '/collection/col1/experiment/exp1/channel/channel10/'
         data = {'description': 'This is a new channel', 'datatype': 'uint8', 'type': 'image', 'default_time_sample': 15}
-        response = self.client.post(url, data=data)
-        self.assertEqual(response.status_code, 400)
-
-    def test_post_channel_with_valid_base_resolution(self):
-        """
-        Post a new channel with the base_resolution
-
-        """
-        # Post a new channel
-        url = '/' + version + '/collection/col1/experiment/exp1/channel/channel10/'
-        data = {'description': 'This is a new channel', 'datatype': 'uint8', 'type': 'image', 'base_resolution': 5}
-        response = self.client.post(url, data=data)
-        self.assertEqual(response.status_code, 201)
-
-    def test_post_channel_with_invalid_base_resolution(self):
-        """
-        Post a new channel with the an invalid base_resolution
-
-        """
-        # Post a new channel
-        url = '/' + version + '/collection/col1/experiment/exp1/channel/channel10/'
-        data = {'description': 'This is a new channel', 'datatype': 'uint8', 'type': 'image', 'base_resolution': 15}
         response = self.client.post(url, data=data)
         self.assertEqual(response.status_code, 400)
 


### PR DESCRIPTION
Now operating under assumption that base resolution sets the level of
the most detailed data.  Num hierarchy levels _n_ means that there
exists lower resolution data from base resolution + 1 to
base resolution + n -1.

This change accompanies the Neuroglancer update to also use base
resolution (8ed1120). https://github.com/jhuapl-boss/neuroglancer/pull/4