### PR TITLE
Fix usage of constants

### DIFF
--- a/django/bosscore/constants.py
+++ b/django/bosscore/constants.py
@@ -21,5 +21,5 @@ ADMIN_USER = 'bossadmin'
 ADMIN_GRP = 'admin'
 
 # Public group
-PUBLIC_GRP = 'bosspublic'
+PUBLIC_GRP = 'public'
 

--- a/django/bosscore/privileges.py
+++ b/django/bosscore/privileges.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from django.contrib.auth.models import User, Group
 from functools import wraps
+from bosscore.constants import PUBLIC_GRP
 from bosscore.error import BossHTTPError, ErrorCodes
 from bosscore.serializers import BossRoleSerializer
 from .models import BossRole, BossGroup
@@ -53,7 +54,7 @@ def load_user_roles(user, roles):
                 return BossHTTPError("{}".format(serializer.errors), ErrorCodes.SERIALIZATION_ERROR)
 
     groups = user.groups.all()
-    to_assign = [user.username + '-primary', 'public']
+    to_assign = [user.username + '-primary', PUBLIC_GRP]
     if 'superuser' in roles:
         to_assign.append('admin')
     for name in to_assign:

--- a/django/bosscore/test/setup_db.py
+++ b/django/bosscore/test/setup_db.py
@@ -20,6 +20,7 @@ from guardian.shortcuts import assign_perm
 
 from ..models import Collection, Experiment, CoordinateFrame, Channel, BossLookup, BossRole, BossGroup
 from ..views.views_resource import ChannelDetail
+from ..constants import ADMIN_USER, ADMIN_GRP, PUBLIC_GRP
 
 from spdb.spatialdb.test.setup import AWSSetupLayer
 
@@ -44,7 +45,7 @@ class SetupTestDB:
         user_primary_group, created = Group.objects.get_or_create(name=username + '-primary')
 
         # add the user to the public group and primary group
-        public_group, created = Group.objects.get_or_create(name='public')
+        public_group, created = Group.objects.get_or_create(name=PUBLIC_GRP)
         self.user.groups.add(user_primary_group)
         public_group.user_set.add(self.user)
         return self.user
@@ -55,13 +56,13 @@ class SetupTestDB:
         BossRole.objects.create(user=user, role=role_name)
 
     def create_super_user(self):
-        self.user = User.objects.create_superuser(username='bossadmin', email='bossadmin@theboss.io',
-                                                  password='bossadmin')
-        user_primary_group, created = Group.objects.get_or_create(name='bossadmin' + '-primary')
+        self.user = User.objects.create_superuser(username=ADMIN_USER, email=ADMIN_USER+'@theboss.io',
+                                                  password=ADMIN_USER)
+        user_primary_group, created = Group.objects.get_or_create(name=ADMIN_USER+'-primary')
 
         # add the user to the public group and primary group and admin group
-        public_group, created = Group.objects.get_or_create(name='public')
-        admin_group, created = Group.objects.get_or_create(name='admin')
+        public_group, created = Group.objects.get_or_create(name=PUBLIC_GRP)
+        admin_group, created = Group.objects.get_or_create(name=ADMIN_GRP)
         self.user.groups.add(user_primary_group)
         self.user.groups.add(public_group)
         self.user.groups.add(admin_group)

--- a/django/bosscore/test/test_group_views.py
+++ b/django/bosscore/test/test_group_views.py
@@ -16,6 +16,7 @@ import json
 from rest_framework.test import APITestCase
 from django.conf import settings
 from .setup_db import SetupTestDB
+from ..constants import PUBLIC_GRP, ADMIN_GRP, ADMIN_USER
 
 version = settings.BOSS_VERSION
 
@@ -46,7 +47,7 @@ class GroupsTests(APITestCase):
         url = '/' + version + '/groups/'
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(set(response.data['groups']), set(['public', 'testuser-primary', 'unittest']))
+        self.assertEqual(set(response.data['groups']), set([PUBLIC_GRP, 'testuser-primary', 'unittest']))
 
     def test_get_groups_groupname(self):
         """ Get all groups for a user"""
@@ -107,7 +108,7 @@ class GroupsTests(APITestCase):
         url = '/' + version + '/groups/?filter=member'
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(set(response.data['groups']), set(['public', 'testuser-primary', 'unittest']))
+        self.assertEqual(set(response.data['groups']), set([PUBLIC_GRP, 'testuser-primary', 'unittest']))
 
     def test_get_groups_filter_maintainers(self):
         """ Get all groups for a user is a member of """
@@ -236,12 +237,12 @@ class GroupMemberTests(APITestCase):
         """ Add a new member to admin or public group. This is invalid """
 
         # Add user to the group
-        url = '/' + version + '/groups/admin/members/testuser2555/'
+        url = '/' + version + '/groups/' + ADMIN_GRP + '/members/testuser2555/'
         response = self.client.post(url)
         self.assertEqual(response.status_code, 400)
 
         # Add user to the group
-        url = '/' + version + '/groups/public/members/testuser2555/'
+        url = '/' + version + '/groups/' + PUBLIC_GRP + '/members/testuser2555/'
         response = self.client.post(url)
         self.assertEqual(response.status_code, 400)
 
@@ -249,12 +250,12 @@ class GroupMemberTests(APITestCase):
         """ Remove a new member to admin or public group. This is invalid """
 
         # Add user to the group
-        url = '/' + version + '/groups/admin/members/testuser2555/'
+        url = '/' + version + '/groups/' + ADMIN_GRP + '/members/testuser2555/'
         response = self.client.delete(url)
         self.assertEqual(response.status_code, 400)
 
         # Add user to the group
-        url = '/' + version + '/groups/public/members/testuser2555/'
+        url = '/' + version + '/groups/' + PUBLIC_GRP + '/members/testuser2555/'
         response = self.client.delete(url)
         self.assertEqual(response.status_code, 400)
 
@@ -286,19 +287,19 @@ class GroupMemberTests(APITestCase):
     def test_remove_bossadmin_member_invalid(self):
 
         # Add user to the group
-        url = '/' + version + '/groups/unittest/members/bossadmin/'
+        url = '/' + version + '/groups/unittest/members/' + ADMIN_USER + '/'
         response = self.client.post(url)
         self.assertEqual(response.status_code, 204)
 
         """ Remove bossadmin member from a group. This is invalid"""
         # Check if user is a member of the group
-        url = '/' + version + '/groups/unittest/members/bossadmin/'
+        url = '/' + version + '/groups/unittest/members/' + ADMIN_USER + '/'
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['result'], True)
 
         # Remove user from the group
-        url = '/' + version + '/groups/unittest/members/bossadmin/'
+        url = '/' + version + '/groups/unittest/members/' + ADMIN_USER + '/'
         response = self.client.delete(url)
         self.assertEqual(response.status_code, 400)
 
@@ -529,13 +530,13 @@ class GroupMaintainerTests(APITestCase):
         """ Test removal of bossadmin as a maintainer of a group fails"""
 
         # Check if bossadmin user is a member of the group
-        url = '/' + version + '/groups/unittest/maintainers/bossadmin/'
+        url = '/' + version + '/groups/unittest/maintainers/' + ADMIN_USER + '/'
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['result'], True)
 
         # Attempt removal of bossadmin from the group
-        url = '/' + version + '/groups/unittest/maintainers/bossadmin/'
+        url = '/' + version + '/groups/unittest/maintainers/' + ADMIN_USER + '/'
         response = self.client.delete(url)
         self.assertEqual(response.status_code, 400)    
 

--- a/django/bosscore/test/test_permission_views.py
+++ b/django/bosscore/test/test_permission_views.py
@@ -14,6 +14,7 @@
 from rest_framework.test import APITestCase
 from django.conf import settings
 from .setup_db import SetupTestDB
+from ..constants import PUBLIC_GRP
 import json
 
 version = settings.BOSS_VERSION
@@ -720,7 +721,7 @@ class PermissionViewsChannelTests(APITestCase):
         url = '/' + version + '/permissions/'
 
         data = {
-            'group': 'public',
+            'group': PUBLIC_GRP,
             'collection': 'col1',
             'experiment': 'exp1',
             'permissions': ['read']
@@ -735,7 +736,7 @@ class PermissionViewsChannelTests(APITestCase):
         url = '/' + version + '/permissions/'
 
         data = {
-            'group': 'public',
+            'group': PUBLIC_GRP,
             'collection': 'col1',
             'experiment': 'exp1',
             'permissions': ['add']
@@ -744,7 +745,7 @@ class PermissionViewsChannelTests(APITestCase):
         self.assertEqual(response.status_code, 400)
 
         data = {
-            'group': 'public',
+            'group': PUBLIC_GRP,
             'collection': 'col1',
             'experiment': 'exp1',
             'permissions': ['read', 'add']
@@ -761,7 +762,7 @@ class PermissionViewsChannelTests(APITestCase):
         # patch permission on a group that the user is not a member or maintainer of.
         url = '/' + version + '/permissions/'
         data = {
-            'group': 'public',
+            'group': PUBLIC_GRP,
             'collection': 'col1',
             'experiment': 'exp1',
             'channel': 'channel1',

--- a/django/bosscore/views/views_group.py
+++ b/django/bosscore/views/views_group.py
@@ -87,7 +87,7 @@ class BossGroupMember(APIView):
 
         """
         try:
-            if group_name == 'public' or group_name == 'admin':
+            if group_name == PUBLIC_GRP or group_name == ADMIN_GRP:
                 return BossHTTPError('Cannot add a member to the group {}. This is an admin managed group'
                                      .format(group_name), ErrorCodes.BAD_REQUEST)
 
@@ -123,15 +123,15 @@ class BossGroupMember(APIView):
 
         """
         try:
-            if group_name == 'public' or group_name == 'admin':
+            if group_name == PUBLIC_GRP or group_name == ADMIN_GRP:
                 return BossHTTPError('Cannot remove a user from the group {}. This is an admin managed group'
                                      .format(group_name), ErrorCodes.BAD_REQUEST)
             group = Group.objects.get(name=group_name)
             bgroup = BossGroup.objects.get(group=group)
 
-            if user_name == 'bossadmin':
-                return BossHTTPError('Cannot remove bossadmin from any group'
-                                     .format(group_name), ErrorCodes.BAD_REQUEST)
+            if user_name == ADMIN_USER:
+                return BossHTTPError('Cannot remove {} from any group'
+                                     .format(ADMIN_USER), ErrorCodes.BAD_REQUEST)
 
             # Check the users permissions.
             if request.user.has_perm("maintain_group", bgroup):
@@ -209,7 +209,7 @@ class BossGroupMaintainer(APIView):
 
         """
         try:
-            if group_name == 'public' or group_name == 'admin':
+            if group_name == PUBLIC_GRP or group_name == ADMIN_GRP:
                 return BossHTTPError('Cannot add a maintainer to the group {}. This is an admin managed group'
                                      .format(group_name), ErrorCodes.BAD_REQUEST)
 
@@ -253,15 +253,15 @@ class BossGroupMaintainer(APIView):
 
         """
         try:
-            if group_name == 'public' or group_name == 'admin':
+            if group_name == PUBLIC_GRP or group_name == ADMIN_GRP:
                 return BossHTTPError('Cannot remove a maintainer from the group {}. This is an admin managed group'
                                      .format(group_name), ErrorCodes.BAD_REQUEST)
             if user_name is None:
                 return BossHTTPError('Missing username parameter in post.', ErrorCodes.INVALID_URL)
             
-            elif user_name == 'bossadmin':
-                return BossHTTPError('Cannot remove boassadmin maintainer from any group',
-                                     ErrorCodes.BAD_REQUEST)
+            elif user_name == ADMIN_USER:
+                return BossHTTPError('Cannot remove {} maintainer from any group'
+                                     .format(ADMIN_USER), ErrorCodes.BAD_REQUEST)
 
             group = Group.objects.get(name=group_name)
             bgroup = BossGroup.objects.get(group=group)
@@ -428,7 +428,7 @@ class BossUserGroup(APIView):
             bgroup = BossGroup.objects.get(group=group)
             bpm = BossPrivilegeManager(request.user)
             if request.user == bgroup.creator or bpm.has_role('admin'):
-                if group_name == 'admin' or group_name == 'public':
+                if group_name == ADMIN_GRP or group_name == PUBLIC_GRP:
                     return BossHTTPError('Admin and public groups cannot be deleted.',
                                         ErrorCodes.BAD_REQUEST)  
                 else:

--- a/django/bosscore/views/views_permission.py
+++ b/django/bosscore/views/views_permission.py
@@ -24,6 +24,7 @@ from guardian.shortcuts import get_perms_for_model, get_objects_for_group, get_p
 
 from bosscore.models import Collection, Experiment, Channel, BossGroup
 from bosscore.permissions import BossPermissionManager, check_is_member_or_maintainer
+from bosscore.constants import PUBLIC_GRP
 from bosscore.error import BossHTTPError, BossError, ErrorCodes, BossResourceNotFoundError,\
     BossGroupNotFoundError, BossPermissionError
 from bosscore.privileges import check_role
@@ -241,7 +242,7 @@ class ResourceUserPermission(APIView):
 
         try:
             # public group can only have read permission
-            if group_name == 'public' and not (set(perm_list).issubset({'read', 'read_volumetric_data'})):
+            if group_name == PUBLIC_GRP and not (set(perm_list).issubset({'read', 'read_volumetric_data'})):
                 return BossHTTPError("The public group can only have read permissions",
                                      ErrorCodes.INVALID_POST_ARGUMENT)
 
@@ -298,7 +299,7 @@ class ResourceUserPermission(APIView):
 
         try:
             # public group can only have read permission
-            if group_name == 'public' and (len(perm_list) != 1 or perm_list[0] != 'read'):
+            if group_name == PUBLIC_GRP and (len(perm_list) != 1 or perm_list[0] != 'read'):
                 return BossHTTPError("The public group can only have read permissions",
                                      ErrorCodes.INVALID_POST_ARGUMENT)
             # If the user is not a member or maintainer of the group, they cannot patch permissions


### PR DESCRIPTION
When adding the Ingest size check I discovered that there is a file with constants, that was not being used. This PR converts all of the hardcoded string for `public`, `admin`, and `bossadmin` to use the constant references, making it easier to change those values in the future (if desired).