### PR TITLE
Django 2.2.x upgrade

### DIFF
--- a/django/boss/settings/base.py
+++ b/django/boss/settings/base.py
@@ -69,16 +69,19 @@ INSTALLED_APPS = [
     'bootstrapform', # style management console
     'bossingest',
     'bossobject',
-    'rest_framework_swagger',
+    #'rest_framework_swagger',
+    'drf_yasg',
     'guardian'
 ]
 
-MIDDLEWARE_CLASSES = (
+#MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    # This one is now a pass-thru
+    #'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',

--- a/django/boss/settings/keycloak.py
+++ b/django/boss/settings/keycloak.py
@@ -19,6 +19,14 @@ from bossoidc.settings import BOSSOIDC_LOGIN_URL, BOSSOIDC_LOGOUT_URL
 Run Boss with a local Keycloak instance for testing.
 """
 
+# These are variables used for testing.  Don't copy these to production.py!
+LOCAL_KEYCLOAK_TESTING = True
+KEYCLOAK_ADMIN_USER = 'bossadmin'
+KEYCLOAK_ADMIN_PASSWORD = 'bossadmin'
+
+
+
+
 # Set this here so it's not overriden by any other settings files.
 LOGIN_URL = BOSSOIDC_LOGIN_URL
 LOGOUT_URL = BOSSOIDC_LOGOUT_URL
@@ -36,6 +44,8 @@ REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] = (
 
 #AUTHENTICATION_BACKENDS.insert(1, 'mozilla_django_oidc.auth.OIDCAuthenticationBackend') 
 AUTHENTICATION_BACKENDS.insert(1, 'bossoidc.backend.OpenIdConnectBackend') 
+
+LOAD_USER_ROLES = 'bosscore.privileges.load_user_roles'
 
 auth_uri = 'http://localhost:8080/auth/realms/BOSS'
 client_id = 'endpoint'

--- a/django/boss/settings/keycloak.py
+++ b/django/boss/settings/keycloak.py
@@ -1,0 +1,46 @@
+# Copyright 2020 The Johns Hopkins University Applied Physics Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .mysql import *
+
+"""
+Run Boss with a local Keycloak instance for testing.
+"""
+
+INSTALLED_APPS.append("bossoidc")
+INSTALLED_APPS.append("mozilla_django_oidc")
+INSTALLED_APPS.append("rest_framework.authtoken")
+
+REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] = (
+    'mozilla_django_oidc.contrib.drf.OIDCAuthentication',
+    'rest_framework.authentication.SessionAuthentication',
+    'boss.authentication.TokenAuthentication',
+    'oidc_auth.authentication.BearerTokenAuthentication',
+)
+
+AUTHENTICATION_BACKENDS.insert(1, 'mozilla_django_oidc.auth.OIDCAuthenticationBackend') 
+AUTHENTICATION_BACKENDS.insert(1, 'bossoidc.backend.OpenIdConnectBackend') 
+
+auth_uri = 'http://localhost:8080'
+client_id = 'endpoint'
+public_uri = 'http://localhost:8000'
+
+OIDC_OP_AUTHORIZATION_ENDPOINT = auth_uri + '/protocol/openid-connect/auth'
+OIDC_OP_TOKEN_ENDPOINT = auth_uri + '/protocol/openid-connect/token'
+OIDC_OP_USER_ENDPOINT = auth_uri + '/protocol/openid-connect/userinfo'
+OIDC_LOGIN_REDIRECT_URL = public_uri
+OIDC_RP_CLIENT_ID = client_id
+
+from bossoidc.settings import configure_oidc
+configure_oidc(auth_uri, client_id, public_uri)

--- a/django/boss/settings/keycloak.py
+++ b/django/boss/settings/keycloak.py
@@ -52,7 +52,7 @@ OIDC_OP_AUTHORIZATION_ENDPOINT = auth_uri + '/protocol/openid-connect/auth'
 OIDC_OP_TOKEN_ENDPOINT = auth_uri + '/protocol/openid-connect/token'
 OIDC_OP_USER_ENDPOINT = auth_uri + '/protocol/openid-connect/userinfo'
 LOGIN_REDIRECT_URL = public_uri + 'v1/mgmt'
-LOGOUT_REDIRECT_URL = auth_uri + '/protocol/openid-connect/logout'
+LOGOUT_REDIRECT_URL = auth_uri + '/protocol/openid-connect/logout?redirect_uri=' + public_uri
 OIDC_RP_CLIENT_ID = client_id
 OIDC_RP_CLIENT_SECRET = ''
 OIDC_RP_SCOPES = 'sub preferred_username'

--- a/django/boss/settings/keycloak.py
+++ b/django/boss/settings/keycloak.py
@@ -13,10 +13,15 @@
 # limitations under the License.
 
 from .mysql import *
+from bossoidc.settings import BOSSOIDC_LOGIN_URL, BOSSOIDC_LOGOUT_URL
 
 """
 Run Boss with a local Keycloak instance for testing.
 """
+
+# Set this here so it's not overriden by any other settings files.
+LOGIN_URL = BOSSOIDC_LOGIN_URL
+LOGOUT_URL = BOSSOIDC_LOGOUT_URL
 
 INSTALLED_APPS.append("bossoidc")
 INSTALLED_APPS.append("mozilla_django_oidc")
@@ -29,18 +34,36 @@ REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] = (
     'oidc_auth.authentication.BearerTokenAuthentication',
 )
 
-AUTHENTICATION_BACKENDS.insert(1, 'mozilla_django_oidc.auth.OIDCAuthenticationBackend') 
+#AUTHENTICATION_BACKENDS.insert(1, 'mozilla_django_oidc.auth.OIDCAuthenticationBackend') 
 AUTHENTICATION_BACKENDS.insert(1, 'bossoidc.backend.OpenIdConnectBackend') 
 
-auth_uri = 'http://localhost:8080'
+auth_uri = 'http://localhost:8080/auth/realms/BOSS'
 client_id = 'endpoint'
 public_uri = 'http://localhost:8000'
 
 OIDC_OP_AUTHORIZATION_ENDPOINT = auth_uri + '/protocol/openid-connect/auth'
 OIDC_OP_TOKEN_ENDPOINT = auth_uri + '/protocol/openid-connect/token'
 OIDC_OP_USER_ENDPOINT = auth_uri + '/protocol/openid-connect/userinfo'
-OIDC_LOGIN_REDIRECT_URL = public_uri
+#LOGIN_REDIRECT_URL = public_uri + '/openid/callback/login/'
+LOGIN_REDIRECT_URL = public_uri + 'v1/mgmt'
+LOGOUT_REDIRECT_URL = auth_uri + '/protocol/openid-connect/logout'
 OIDC_RP_CLIENT_ID = client_id
+OIDC_RP_CLIENT_SECRET = ''
+OIDC_RP_SCOPES = 'sub preferred_username'
+OIDC_RP_SIGN_ALGO = 'RS256'
+OIDC_RP_IDP_SIGN_KEY = (
+'''-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApgdDYs/B+6XJfuo6mCFW
+/JTafaWE9WcDqZd8jB3rj+DEeZuUg+5wS34ih7YAgv/8L09FAL/rdX2DBxS1Ohmo
+m5Lu4qmZVHy2Xwu6NHVwozWydilldlvu6vAa9ozMtlNNuTTDTyEgCxLbXHEMEpRd
+xVcy5P0kEY2YyvLXAKK5iX+XEnIH3IFbzPBvqwBGneIkGXEYPszXFELaZ2bp0vPI
+ZfFdlb4Nv4FwodLNuKLjEoXLHHscoR3zmuzeq5cJ+i2mzInn4kkEdBXHoADTUvot
+qMNblmEMW8muwAd4i7e4nvfnSRjq7+bPlb1jEOBDL6nd8cU4ACb/p44k0rBggtFV
+aQIDAQAB
+-----END PUBLIC KEY-----''')
+OIDC_OP_JWKS_ENDPOINT = auth_uri + '/protocol/openid-connect/certs'
+# No SSL when running locally during development.
+OIDC_VERIFY_SSL = False
 
 from bossoidc.settings import configure_oidc
 configure_oidc(auth_uri, client_id, public_uri)

--- a/django/boss/settings/keycloak.py
+++ b/django/boss/settings/keycloak.py
@@ -42,10 +42,7 @@ REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] = (
     'oidc_auth.authentication.BearerTokenAuthentication',
 )
 
-#AUTHENTICATION_BACKENDS.insert(1, 'mozilla_django_oidc.auth.OIDCAuthenticationBackend') 
 AUTHENTICATION_BACKENDS.insert(1, 'bossoidc.backend.OpenIdConnectBackend') 
-
-LOAD_USER_ROLES = 'bosscore.privileges.load_user_roles'
 
 auth_uri = 'http://localhost:8080/auth/realms/BOSS'
 client_id = 'endpoint'
@@ -54,26 +51,17 @@ public_uri = 'http://localhost:8000'
 OIDC_OP_AUTHORIZATION_ENDPOINT = auth_uri + '/protocol/openid-connect/auth'
 OIDC_OP_TOKEN_ENDPOINT = auth_uri + '/protocol/openid-connect/token'
 OIDC_OP_USER_ENDPOINT = auth_uri + '/protocol/openid-connect/userinfo'
-#LOGIN_REDIRECT_URL = public_uri + '/openid/callback/login/'
 LOGIN_REDIRECT_URL = public_uri + 'v1/mgmt'
 LOGOUT_REDIRECT_URL = auth_uri + '/protocol/openid-connect/logout'
 OIDC_RP_CLIENT_ID = client_id
 OIDC_RP_CLIENT_SECRET = ''
 OIDC_RP_SCOPES = 'sub preferred_username'
 OIDC_RP_SIGN_ALGO = 'RS256'
-OIDC_RP_IDP_SIGN_KEY = (
-'''-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApgdDYs/B+6XJfuo6mCFW
-/JTafaWE9WcDqZd8jB3rj+DEeZuUg+5wS34ih7YAgv/8L09FAL/rdX2DBxS1Ohmo
-m5Lu4qmZVHy2Xwu6NHVwozWydilldlvu6vAa9ozMtlNNuTTDTyEgCxLbXHEMEpRd
-xVcy5P0kEY2YyvLXAKK5iX+XEnIH3IFbzPBvqwBGneIkGXEYPszXFELaZ2bp0vPI
-ZfFdlb4Nv4FwodLNuKLjEoXLHHscoR3zmuzeq5cJ+i2mzInn4kkEdBXHoADTUvot
-qMNblmEMW8muwAd4i7e4nvfnSRjq7+bPlb1jEOBDL6nd8cU4ACb/p44k0rBggtFV
-aQIDAQAB
------END PUBLIC KEY-----''')
 OIDC_OP_JWKS_ENDPOINT = auth_uri + '/protocol/openid-connect/certs'
 # No SSL when running locally during development.
 OIDC_VERIFY_SSL = False
+
+LOAD_USER_ROLES = 'bosscore.privileges.load_user_roles'
 
 from bossoidc.settings import configure_oidc
 configure_oidc(auth_uri, client_id, public_uri)

--- a/django/boss/settings/production.py
+++ b/django/boss/settings/production.py
@@ -57,8 +57,8 @@ if config['aws']['cache-session'] != '':
     SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
     SESSION_CACHE_ALIAS = 'default'
 
+INSTALLED_APPS.append("bossoidc")
 INSTALLED_APPS.append("mozilla_django_oidc")
-INSTALLED_APPS.append("keycloak_oidc")
 INSTALLED_APPS.append("rest_framework.authtoken")
 
 REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] = (
@@ -68,8 +68,8 @@ REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] = (
     'oidc_auth.authentication.BearerTokenAuthentication',
 )
 
-AUTHENTICATION_BACKENDS.insert(0, 'keycloak_oidc.auth.OIDCAuthenticationBackend') 
-AUTHENTICATION_BACKENDS.insert(0, 'mozilla_django_oidc.auth.OIDCAuthenticationBackend') 
+AUTHENTICATION_BACKENDS.insert(1, 'mozilla_django_oidc.auth.OIDCAuthenticationBackend') 
+AUTHENTICATION_BACKENDS.insert(1, 'bossoidc.backend.OpenIdConnectBackend') 
 
 auth_uri = vault.read('secret/endpoint/auth', 'url')
 client_id = vault.read('secret/endpoint/auth', 'client_id')
@@ -84,8 +84,9 @@ OIDC_RP_CLIENT_ID = client_id
 OIDC_VERIFY_SSL = not (config['auth']['OIDC_VERIFY_SSL'] in ['False', 'false'])
 
 LOAD_USER_ROLES = 'bosscore.privileges.load_user_roles'
-#from bossoidc.settings import *
-#configure_oidc(auth_uri, client_id, public_uri)
+
+from bossoidc.settings import configure_oidc
+configure_oidc(auth_uri, client_id, public_uri)
 
 # Load params for spatialDB once during settings.py
 # kvio settings

--- a/django/boss/settings/production.py
+++ b/django/boss/settings/production.py
@@ -83,7 +83,7 @@ OIDC_OP_AUTHORIZATION_ENDPOINT = auth_uri + '/protocol/openid-connect/auth'
 OIDC_OP_TOKEN_ENDPOINT = auth_uri + '/protocol/openid-connect/token'
 OIDC_OP_USER_ENDPOINT = auth_uri + '/protocol/openid-connect/userinfo'
 LOGIN_REDIRECT_URL = public_uri + 'v1/mgmt'
-LOGOUT_REDIRECT_URL = auth_uri + '/protocol/openid-connect/logout'
+LOGOUT_REDIRECT_URL = auth_uri + '/protocol/openid-connect/logout?redirect_uri=' + public_uri
 OIDC_RP_CLIENT_ID = client_id
 OIDC_RP_CLIENT_SECRET = ''
 OIDC_RP_SCOPES = 'sub preferred_username'

--- a/django/boss/settings/production.py
+++ b/django/boss/settings/production.py
@@ -57,26 +57,35 @@ if config['aws']['cache-session'] != '':
     SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
     SESSION_CACHE_ALIAS = 'default'
 
-INSTALLED_APPS.append("bossoidc")
-INSTALLED_APPS.append("djangooidc")
+INSTALLED_APPS.append("mozilla_django_oidc")
+INSTALLED_APPS.append("keycloak_oidc")
 INSTALLED_APPS.append("rest_framework.authtoken")
-AUTHENTICATION_BACKENDS.insert(1, 'bossoidc.backend.OpenIdConnectBackend')
 
 REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] = (
+    'mozilla_django_oidc.contrib.drf.OIDCAuthentication',
     'rest_framework.authentication.SessionAuthentication',
     'boss.authentication.TokenAuthentication',
     'oidc_auth.authentication.BearerTokenAuthentication',
 )
 
+AUTHENTICATION_BACKENDS.insert(0, 'keycloak_oidc.auth.OIDCAuthenticationBackend') 
+AUTHENTICATION_BACKENDS.insert(0, 'mozilla_django_oidc.auth.OIDCAuthenticationBackend') 
+
 auth_uri = vault.read('secret/endpoint/auth', 'url')
 client_id = vault.read('secret/endpoint/auth', 'client_id')
 public_uri = vault.read('secret/endpoint/auth', 'public_uri')
 
+OIDC_OP_AUTHORIZATION_ENDPOINT = auth_uri + '/protocol/openid-connect/auth'
+OIDC_OP_TOKEN_ENDPOINT = auth_uri + '/protocol/openid-connect/token'
+OIDC_OP_USER_ENDPOINT = auth_uri + '/protocol/openid-connect/userinfo'
+OIDC_LOGIN_REDIRECT_URL = public_uri
+OIDC_RP_CLIENT_ID = client_id
+
 OIDC_VERIFY_SSL = not (config['auth']['OIDC_VERIFY_SSL'] in ['False', 'false'])
 
 LOAD_USER_ROLES = 'bosscore.privileges.load_user_roles'
-from bossoidc.settings import *
-configure_oidc(auth_uri, client_id, public_uri)
+#from bossoidc.settings import *
+#configure_oidc(auth_uri, client_id, public_uri)
 
 # Load params for spatialDB once during settings.py
 # kvio settings

--- a/django/boss/settings/production.py
+++ b/django/boss/settings/production.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from .base import *
+from bossoidc.settings import BOSSOIDC_LOGIN_URL, BOSSOIDC_LOGOUT_URL
 
 """
 Run the boss in production.
@@ -57,6 +58,10 @@ if config['aws']['cache-session'] != '':
     SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
     SESSION_CACHE_ALIAS = 'default'
 
+# Set this here so it's not overriden by any other settings files.
+LOGIN_URL = BOSSOIDC_LOGIN_URL
+LOGOUT_URL = BOSSOIDC_LOGOUT_URL
+
 INSTALLED_APPS.append("bossoidc")
 INSTALLED_APPS.append("mozilla_django_oidc")
 INSTALLED_APPS.append("rest_framework.authtoken")
@@ -68,7 +73,6 @@ REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] = (
     'oidc_auth.authentication.BearerTokenAuthentication',
 )
 
-AUTHENTICATION_BACKENDS.insert(1, 'mozilla_django_oidc.auth.OIDCAuthenticationBackend') 
 AUTHENTICATION_BACKENDS.insert(1, 'bossoidc.backend.OpenIdConnectBackend') 
 
 auth_uri = vault.read('secret/endpoint/auth', 'url')
@@ -78,9 +82,13 @@ public_uri = vault.read('secret/endpoint/auth', 'public_uri')
 OIDC_OP_AUTHORIZATION_ENDPOINT = auth_uri + '/protocol/openid-connect/auth'
 OIDC_OP_TOKEN_ENDPOINT = auth_uri + '/protocol/openid-connect/token'
 OIDC_OP_USER_ENDPOINT = auth_uri + '/protocol/openid-connect/userinfo'
-OIDC_LOGIN_REDIRECT_URL = public_uri
+LOGIN_REDIRECT_URL = public_uri + 'v1/mgmt'
+LOGOUT_REDIRECT_URL = auth_uri + '/protocol/openid-connect/logout'
 OIDC_RP_CLIENT_ID = client_id
-
+OIDC_RP_CLIENT_SECRET = ''
+OIDC_RP_SCOPES = 'sub preferred_username'
+OIDC_RP_SIGN_ALGO = 'RS256'
+OIDC_OP_JWKS_ENDPOINT = auth_uri + '/protocol/openid-connect/certs'
 OIDC_VERIFY_SSL = not (config['auth']['OIDC_VERIFY_SSL'] in ['False', 'false'])
 
 LOAD_USER_ROLES = 'bosscore.privileges.load_user_roles'

--- a/django/boss/urls.py
+++ b/django/boss/urls.py
@@ -49,7 +49,7 @@ schema_view = get_schema_view(
 
 urlpatterns = [
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
     #url(r'^docs/', include('rest_framework_swagger.urls')),
     url(r'^docs/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     url(r'^ping/', views.Ping.as_view()),

--- a/django/boss/urls.py
+++ b/django/boss/urls.py
@@ -83,7 +83,7 @@ urlpatterns = [
 
     # Management Console Urls
     url(r'^v1/mgmt/', include('mgmt.urls', namespace='mgmt')),
-    url(r'^/?$', RedirectView.as_view(pattern_name='mgmt:home')),
+    url(r'^$', RedirectView.as_view(pattern_name='mgmt:home')),
 
     #Object urls
     url(r'^v1/reserve/', include('bossobject.urls.reserve_urls', namespace='v1')),

--- a/django/boss/urls.py
+++ b/django/boss/urls.py
@@ -32,13 +32,26 @@ from django.conf.urls import url
 from django.contrib import admin
 from django.conf.urls import include
 from django.views.generic import RedirectView
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
 
 from . import views
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title='BOSS API',
+        default_version='v1',
+    ),
+    public=True,
+    permission_classes=(permissions.AllowAny,)
+)
 
 urlpatterns = [
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^docs/', include('rest_framework_swagger.urls')),
+    #url(r'^docs/', include('rest_framework_swagger.urls')),
+    url(r'^docs/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     url(r'^ping/', views.Ping.as_view()),
     url(r'^token/', views.Token.as_view()),
 

--- a/django/boss/urls.py
+++ b/django/boss/urls.py
@@ -93,3 +93,6 @@ urlpatterns = [
 
 if 'djangooidc' in settings.INSTALLED_APPS:
     urlpatterns.append(url(r'^openid/', include('djangooidc.urls')))
+
+if 'mozilla_django_oidc' in settings.INSTALLED_APPS:
+    urlpatterns.append(url(r'^openid/', include('mozilla_django_oidc.urls')))

--- a/django/bosscore/models.py
+++ b/django/bosscore/models.py
@@ -313,7 +313,7 @@ class BossGroup(models.Model):
     """
     Store group information
     """
-    group = models.OneToOneField(Group)
+    group = models.OneToOneField(Group, on_delete=models.CASCADE)
     creator = models.ForeignKey('auth.User', on_delete=models.CASCADE, related_name='Bossgroup')
 
     class Meta:

--- a/django/bosscore/models.py
+++ b/django/bosscore/models.py
@@ -31,7 +31,7 @@ class Collection(models.Model):
     name = models.CharField(max_length=255, verbose_name="Name of the Collection",
                             validators=[NameValidator()], unique=True)
     description = models.CharField(max_length=4096, blank=True)
-    creator = models.ForeignKey('auth.User', related_name='collections')
+    creator = models.ForeignKey('auth.User', on_delete=models.CASCADE, related_name='collections')
     to_be_deleted = models.DateTimeField(null=True, blank=True)
     DELETED_STATUS_CHOICES = (
         ('started', 'STARTED'),
@@ -67,7 +67,7 @@ class CoordinateFrame(models.Model):
     name = models.CharField(max_length=255, verbose_name="Name of the Coordinate reference frame",
                             validators=[NameValidator()], unique=True)
     description = models.CharField(max_length=4096, blank=True)
-    creator = models.ForeignKey('auth.User', related_name='coordinateframes')
+    creator = models.ForeignKey('auth.User', on_delete=models.CASCADE, related_name='coordinateframes')
 
     x_start = models.IntegerField()
     x_stop = models.IntegerField()
@@ -130,7 +130,7 @@ class Experiment(models.Model):
     collection = models.ForeignKey(Collection, related_name='experiments', on_delete=models.PROTECT)
     name = models.CharField(max_length=255, verbose_name="Name of the Experiment", validators=[NameValidator()])
     description = models.CharField(max_length=4096, blank=True)
-    creator = models.ForeignKey('auth.User', related_name='experiment')
+    creator = models.ForeignKey('auth.User', on_delete=models.CASCADE, related_name='experiment')
 
     coord_frame = models.ForeignKey(CoordinateFrame, related_name='exps', on_delete=models.PROTECT)
     num_hierarchy_levels = models.IntegerField(default=1)
@@ -181,7 +181,7 @@ class Channel(models.Model):
     """
     name = models.CharField(max_length=255, verbose_name="Name of the Channel", validators=[NameValidator()])
     description = models.CharField(max_length=4096, blank=True)
-    creator = models.ForeignKey('auth.User', related_name='Channel')
+    creator = models.ForeignKey('auth.User', on_delete=models.CASCADE, related_name='Channel')
 
     experiment = models.ForeignKey(Experiment, related_name='channels', on_delete=models.PROTECT)
     base_resolution = models.IntegerField(default=0)
@@ -264,7 +264,7 @@ class Channel(models.Model):
 
 
 class Source(models.Model):
-    derived_channel = models.ForeignKey(Channel, related_name='derived_channel')
+    derived_channel = models.ForeignKey(Channel, on_delete=models.CASCADE, related_name='derived_channel')
     source_channel = models.ForeignKey(Channel, related_name='source_channel', on_delete=models.PROTECT)
 
 
@@ -314,7 +314,7 @@ class BossGroup(models.Model):
     Store group information
     """
     group = models.OneToOneField(Group)
-    creator = models.ForeignKey('auth.User', related_name='Bossgroup')
+    creator = models.ForeignKey('auth.User', on_delete=models.CASCADE, related_name='Bossgroup')
 
     class Meta:
         db_table = u"bossgroup"

--- a/django/bosscore/test/test_urls.py
+++ b/django/bosscore/test/test_urls.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from rest_framework.test import APITestCase
-from django.core.urlresolvers import resolve
+from django.urls import resolve
 
 from django.conf import settings
 

--- a/django/bosscore/urls/coord_urls.py
+++ b/django/bosscore/urls/coord_urls.py
@@ -15,6 +15,7 @@
 from django.conf.urls import url
 from bosscore.views import views_resource
 
+app_name = 'bosscore'
 urlpatterns = [
     # Specific coordinate frame
      url(r'(?P<coordframe>[\w_-]+)/?$', views_resource.CoordinateFrameDetail.as_view()),

--- a/django/bosscore/urls/group-urls.py
+++ b/django/bosscore/urls/group-urls.py
@@ -15,6 +15,7 @@
 from django.conf.urls import url
 from bosscore.views import views_group
 
+app_name = 'bosscore'
 urlpatterns = [
 
     # urls to manage adding and removing users from groups
@@ -29,6 +30,5 @@ urlpatterns = [
 
     # URLS to manage groups
     url(r'^', views_group.BossUserGroup.as_view()),
-
 
 ]

--- a/django/bosscore/urls/permission-urls.py
+++ b/django/bosscore/urls/permission-urls.py
@@ -15,6 +15,7 @@
 from django.conf.urls import url
 from bosscore.views import views_permission
 
+app_name = 'bosscore'
 urlpatterns = [
 
     # URLS for permissions - Group to resource

--- a/django/bosscore/urls/resource_urls.py
+++ b/django/bosscore/urls/resource_urls.py
@@ -15,6 +15,7 @@
 from django.conf.urls import url
 from bosscore.views import views_resource
 
+app_name = 'bosscore'
 urlpatterns = [
 
     # # An instance of channel

--- a/django/bossingest/models.py
+++ b/django/bossingest/models.py
@@ -20,7 +20,7 @@ class IngestJob(models.Model):
     Django Model representing an ingest job
     """
 
-    creator = models.ForeignKey(settings.AUTH_USER_MODEL)
+    creator = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     start_date = models.DateTimeField(auto_now_add=True)
     end_date = models.DateTimeField(null=True)
 

--- a/django/bossingest/serializers.py
+++ b/django/bossingest/serializers.py
@@ -22,6 +22,7 @@ class IngestJobCreateSerializer(serializers.ModelSerializer):
     """
     class Meta:
         model = IngestJob
+        fields = '__all__'
 
 
 class IngestJobListSerializer(serializers.ModelSerializer):

--- a/django/bossingest/test/test_urls.py
+++ b/django/bossingest/test/test_urls.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from rest_framework.test import APITestCase
-from django.core.urlresolvers import resolve
+from django.urls import resolve
 from django.conf import settings
 from bossingest.views import IngestJobView, IngestJobStatusView, IngestJobCompleteView
 

--- a/django/bossingest/urls.py
+++ b/django/bossingest/urls.py
@@ -15,6 +15,7 @@
 from django.conf.urls import url
 from bossingest import views
 
+app_name = 'bossingest'
 urlpatterns = [
     url(r'(?P<ingest_job_id>[\d]+)/status/?$', views.IngestJobStatusView.as_view()),
     url(r'(?P<ingest_job_id>[\d]+)/complete/?$', views.IngestJobCompleteView.as_view()),

--- a/django/bossmeta/test/test_urls.py
+++ b/django/bossmeta/test/test_urls.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from rest_framework.test import APITestCase
-from django.core.urlresolvers import resolve
+from django.urls import resolve
 from django.conf import settings
 from bossmeta.views import BossMeta
 

--- a/django/bossmeta/urls.py
+++ b/django/bossmeta/urls.py
@@ -15,10 +15,12 @@
 from django.conf.urls import url
 from . import views
 
+app_name = 'bossmeta'
 urlpatterns = [
 
     # Urls related to metadata
     url(r'(?P<collection>[\w_-]+)/(?P<experiment>[\w_-]+)/(?P<channel>[\w_-]+)/?', views.BossMeta.as_view()),
     url(r'(?P<collection>[\w_-]+)/(?P<experiment>[\w_-]+)/?', views.BossMeta.as_view()),
     url(r'(?P<collection>[\w_\-]+)/?$', views.BossMeta.as_view()),
+
 ]

--- a/django/bossobject/test/test_urls.py
+++ b/django/bossobject/test/test_urls.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from rest_framework.test import APITestCase
-from django.core.urlresolvers import resolve
+from django.urls import resolve
 from django.conf import settings
 
 from bossobject.views import Reserve, Ids, BoundingBox

--- a/django/bossobject/urls/boundingbox_urls.py
+++ b/django/bossobject/urls/boundingbox_urls.py
@@ -15,6 +15,7 @@
 from django.conf.urls import url
 from bossobject import views
 
+app_name = 'bossobject'
 urlpatterns = [
 
     # Url to get the bouding box for an object

--- a/django/bossobject/urls/ids_urls.py
+++ b/django/bossobject/urls/ids_urls.py
@@ -15,6 +15,7 @@
 from django.conf.urls import url
 from bossobject import views
 
+app_name = 'bossobject'
 urlpatterns = [
 
     # Url to handle cutout with a collection, experiment, channel/annotation project and  range time

--- a/django/bossobject/urls/reserve_urls.py
+++ b/django/bossobject/urls/reserve_urls.py
@@ -15,6 +15,7 @@
 from django.conf.urls import url
 from bossobject import views
 
+app_name = 'bossobject'
 urlpatterns = [
 
     # Url to reserve ids for a channel

--- a/django/bossspatialdb/test/test_routing.py
+++ b/django/bossspatialdb/test/test_routing.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.core.urlresolvers import resolve
+from django.urls import resolve
 from ..views import Cutout
 
 from rest_framework.test import APITestCase

--- a/django/bossspatialdb/urls.py
+++ b/django/bossspatialdb/urls.py
@@ -16,6 +16,7 @@ from django.conf.urls import url
 from django.contrib.auth.decorators import login_required
 from . import views
 
+app_name = 'bossspatialdb'
 urlpatterns = [
 
 

--- a/django/bossspatialdb/urls_downsample.py
+++ b/django/bossspatialdb/urls_downsample.py
@@ -16,6 +16,7 @@ from django.conf.urls import url
 from django.contrib.auth.decorators import login_required
 from . import views
 
+app_name = 'bossspatialdb'
 urlpatterns = [
     # Url to handle cutout with a collection, experiment, channel
     url(r'^(?P<collection>[\w_-]+)/(?P<experiment>[\w_-]+)/(?P<channel>[\w_-]+)/?$', views.Downsample.as_view()),

--- a/django/bosstiles/image_urls.py
+++ b/django/bosstiles/image_urls.py
@@ -15,6 +15,7 @@
 from django.conf.urls import url
 from bosstiles import views
 
+app_name = 'bosstiles'
 urlpatterns = [
     # Url to handle cutout with a collection, experiment, channel/annotation project
     url(r'^(?P<collection>[\w_-]+)/(?P<experiment>[\w_-]+)/(?P<channel>[\w_-]+)/(?P<orientation>(xy|xz|yz))/(?P<resolution>\d)/(?P<x_args>\d+(:\d+)?)/(?P<y_args>\d+(:\d+)?)/(?P<z_args>\d+(:\d+)?)/?(?P<t_args>\d+)?/?.*$',

--- a/django/bosstiles/test/test_routing.py
+++ b/django/bosstiles/test/test_routing.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.core.urlresolvers import resolve
+from django.urls import resolve
 from bosstiles.views import Tile, CutoutTile
 
 from rest_framework.test import APITestCase

--- a/django/bosstiles/tile_urls.py
+++ b/django/bosstiles/tile_urls.py
@@ -15,6 +15,7 @@
 from django.conf.urls import url
 from bosstiles import views
 
+app_name = 'bosstiles'
 urlpatterns = [
     # Url to handle cutout with a collection, experiment, channel/annotation project
     url(r'^(?P<collection>[\w_-]+)/(?P<experiment>[\w_-]+)/(?P<channel>[\w_-]+)/(?P<orientation>(xy|xz|yz))/(?P<tile_size>\d+)/(?P<resolution>\d)/(?P<x_idx>\d+)/(?P<y_idx>\d+)/(?P<z_idx>\d+)/?(?P<t_idx>\d+)?/?.*$',

--- a/django/mgmt/api.py
+++ b/django/mgmt/api.py
@@ -39,7 +39,7 @@ def error_response(request, resp, category, category_name=None):
         'message': error_message(resp),
     }
 
-    page = render_to_string('error.html', args, RequestContext(request))
+    page = render_to_string('error.html', args, request)
     return HttpResponse(page, status=resp.status_code)
 
 

--- a/django/mgmt/templates/base.html
+++ b/django/mgmt/templates/base.html
@@ -67,6 +67,11 @@
         $("#contentTab a[href='#" + pane + "']").tab("show");
         err.parents(".modal").modal("show");
       }
+
+      // Make the <a> element submit the logout form.
+      $("#logout_link").on("click", evt => {
+        $("#logout_form").submit();
+      });
     });
 
 
@@ -106,9 +111,10 @@
             <ul class="dropdown-menu">
               <li id="token_dropdown"><a id="token" href="{% url 'mgmt:token' %}">API Token</a></li>
               <li>
-                <form action="{% url 'oidc_logout' %}" method="post">
+                <a id="logout_link">Logout</a>
+                <form id="logout_form" style="display: none;" action="{% url 'oidc_logout' %}" method="post">
                   {% csrf_token %}
-                  <input id="logout" type="submit" value="logout">
+                  <input type="submit" value="logout">
                 </form>
               </li>
               <!-- <li><a id="logout" href="{% url 'oidc_logout' %}">Logout</a></li> -->

--- a/django/mgmt/templates/base.html
+++ b/django/mgmt/templates/base.html
@@ -105,7 +105,13 @@
             </a>
             <ul class="dropdown-menu">
               <li id="token_dropdown"><a id="token" href="{% url 'mgmt:token' %}">API Token</a></li>
-              <li><a id="logout" href="{% url 'logout' %}">Logout</a></li>
+              <li>
+                <form action="{% url 'oidc_logout' %}" method="post">
+                  {% csrf_token %}
+                  <input id="logout" type="submit" value="logout">
+                </form>
+              </li>
+              <!-- <li><a id="logout" href="{% url 'oidc_logout' %}">Logout</a></li> -->
             </ul>
           </li>
         </ul>

--- a/django/mgmt/urls.py
+++ b/django/mgmt/urls.py
@@ -15,6 +15,7 @@
 from django.conf.urls import url
 from . import views
 
+app_name = 'mgmt'
 urlpatterns = [
     url(r'users/?', views.Users.as_view(), name='users'),
     url(r'user/(?P<username>[\w_-]+)/?', views.User.as_view(), name='user'),

--- a/django/mgmt/views.py
+++ b/django/mgmt/views.py
@@ -3,7 +3,7 @@ from django.views.generic import View
 from django.template.loader import render_to_string
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import redirect
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from bosscore.privileges import BossPrivilegeManager, check_role
 from bosscore.error import BossError

--- a/django/mgmt/views.py
+++ b/django/mgmt/views.py
@@ -4,6 +4,7 @@ from django.template.loader import render_to_string
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import redirect
 from django.urls import reverse
+from django.utils import timezone
 
 from bosscore.privileges import BossPrivilegeManager, check_role
 from bosscore.error import BossError
@@ -16,7 +17,6 @@ from .forms import ResourcePermissionsForm, GroupPermissionsForm
 from . import api
 from . import utils
 from .models import SystemNotice, BlogPost
-import datetime
 
 # import as to deconflict with our Token class
 from rest_framework.authtoken.models import Token as TokenModel
@@ -41,7 +41,7 @@ def get_roles(request):
 class Home(LoginRequiredMixin, View):
     def get(self, request):
         # Get System Notices
-        now_datetime = datetime.datetime.now()
+        now_datetime = timezone.now()
         notices = SystemNotice.objects.filter(show_on__lte=now_datetime, hide_on__gte=now_datetime)
         notice_data = []
         for n in notices:

--- a/django/mgmt/views.py
+++ b/django/mgmt/views.py
@@ -1,7 +1,6 @@
 from django.http import HttpResponse, HttpResponseRedirect
 from django.views.generic import View
 from django.template.loader import render_to_string
-from django.template import RequestContext
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import redirect
 from django.core.urlresolvers import reverse
@@ -62,7 +61,7 @@ class Home(LoginRequiredMixin, View):
             'alerts': notice_data,
             'blog_posts': blog_data
         }
-        return HttpResponse(render_to_string('home.html', args, RequestContext(request)))
+        return HttpResponse(render_to_string('home.html', args, request=request))
 
 
 class Users(LoginRequiredMixin, View):
@@ -110,7 +109,7 @@ class Users(LoginRequiredMixin, View):
             'user_form': user_form if user_form else UserForm(),
             'user_error': "error" if user_form else "",
         }
-        return HttpResponse(render_to_string('users.html', args, RequestContext(request)))
+        return HttpResponse(render_to_string('users.html', args, request=request))
 
     def post(self, request):
         form = UserForm(request.POST)
@@ -178,7 +177,7 @@ class User(LoginRequiredMixin, View):
             'role_form': role_form if role_form else RoleForm(),
             'role_error': "error" if role_form else "",
         }
-        return HttpResponse(render_to_string('user.html', args, RequestContext(request)))
+        return HttpResponse(render_to_string('user.html', args, request=request))
 
     def post(self, request, username):
         form = RoleForm(request.POST)
@@ -208,7 +207,7 @@ class Token(LoginRequiredMixin, View):
             'token': token,
             'button': button,
         }
-        return HttpResponse(render_to_string('token.html', args, RequestContext(request)))
+        return HttpResponse(render_to_string('token.html', args, request=request))
 
     def post(self, request):
         try:
@@ -230,7 +229,7 @@ class Groups(LoginRequiredMixin, View):
             'group_form': group_form if group_form else GroupForm(),
             'group_error': "error" if group_form else ""
         }
-        return HttpResponse(render_to_string('groups.html', args, RequestContext(request)))
+        return HttpResponse(render_to_string('groups.html', args, request=request))
 
     def post(self, request):
         form = GroupForm(request.POST)
@@ -329,7 +328,7 @@ class Group(LoginRequiredMixin, View):
             'perms_form': perms_form if perms_form else GroupPermissionsForm(),
             'perms_error': "error" if perms_form else "",
         }
-        return HttpResponse(render_to_string('group.html', args, RequestContext(request)))
+        return HttpResponse(render_to_string('group.html', args, request=request))
 
     def post(self, request, group_name):
         action = request.GET.get('action')  # URL parameter
@@ -382,7 +381,7 @@ class Resources(LoginRequiredMixin, View):
                                                                                                      "z_start": 0}),
             'coord_error': "error" if coord_form else "",
         }
-        return HttpResponse(render_to_string('collections.html', args, RequestContext(request)))
+        return HttpResponse(render_to_string('collections.html', args, request=request))
 
     def post(self, request):
         print(request.POST)
@@ -434,7 +433,7 @@ class CoordinateFrame(LoginRequiredMixin, View):
             'coord_form': coord_form,
             'coord_error': coord_error,
         }
-        return HttpResponse(render_to_string('coordinate_frame.html', args, RequestContext(request)))
+        return HttpResponse(render_to_string('coordinate_frame.html', args, request=request))
 
     @check_role("resource-manager")
     def post(self, request, coord_name):
@@ -499,7 +498,7 @@ class Collection(LoginRequiredMixin, View):
             'perms_form': perms_form if perms_form else ResourcePermissionsForm(),
             'perms_error': "error" if perms_form else "",
         }
-        return HttpResponse(render_to_string('collection.html', args, RequestContext(request)))
+        return HttpResponse(render_to_string('collection.html', args, request=request))
 
     def post(self, request, collection_name):
         action = request.GET.get('action')  # URL parameter
@@ -602,7 +601,7 @@ class Experiment(LoginRequiredMixin, View):
             'perms_form': perms_form if perms_form else ResourcePermissionsForm(),
             'perms_error': "error" if perms_form else "",
         }
-        return HttpResponse(render_to_string('experiment.html', args, RequestContext(request)))
+        return HttpResponse(render_to_string('experiment.html', args, request=request))
 
     def post(self, request, collection_name, experiment_name):
         action = request.GET.get('action')  # URL parameter
@@ -703,7 +702,7 @@ class Channel(LoginRequiredMixin, View):
             'perms_form': perms_form if perms_form else ResourcePermissionsForm(),
             'perms_error': "error" if perms_form else "",
         }
-        return HttpResponse(render_to_string('channel.html', args, RequestContext(request)))
+        return HttpResponse(render_to_string('channel.html', args, request=request))
 
     def post(self, request, collection_name, experiment_name, channel_name):
         action = request.GET.get('action')  # URL parameter
@@ -786,7 +785,7 @@ class Meta(LoginRequiredMixin, View):
             'meta_error': meta_error,
             'back_url': back_url
         }
-        return HttpResponse(render_to_string('meta.html', args, RequestContext(request)))
+        return HttpResponse(render_to_string('meta.html', args, request=request))
 
     @check_role("resource-manager")
     def post(self, request, collection, experiment=None, channel=None):
@@ -817,9 +816,9 @@ class IngestJob(LoginRequiredMixin, View):
 
         if not ingest_job_id:
             # This is just the main ingest job listing
-            return HttpResponse(render_to_string('ingest_jobs.html', args, RequestContext(request)))
+            return HttpResponse(render_to_string('ingest_jobs.html', args, request=request))
 
         else:
             # This is a single ingest job
-            return HttpResponse(render_to_string('ingest_job.html', args, RequestContext(request)))
+            return HttpResponse(render_to_string('ingest_job.html', args, request=request))
 

--- a/django/sso/urls/user-role-urls.py
+++ b/django/sso/urls/user-role-urls.py
@@ -15,6 +15,7 @@
 from django.conf.urls import url
 from sso.views import views_user
 
+app_name = 'sso'
 urlpatterns = [
 
     # URLS to add role

--- a/django/sso/urls/user-urls.py
+++ b/django/sso/urls/user-urls.py
@@ -15,6 +15,7 @@
 from django.conf.urls import url
 from sso.views import views_user
 
+app_name = 'sso'
 urlpatterns = [
 
     # URLS to add a user

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ wheel==0.24.0
 uWSGI==2.0.12
 
 drf-oidc-auth==0.10.0
--e git+http://github.com/jhuapl-boss/boss-oidc.git#egg=boss-oidc
+-e git+https://github.com/jhuapl-boss/boss-oidc.git@mozilla#egg=boss-oidc
 
 mozilla-django-oidc==1.2.3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 boto3>=1.4.0
-Django==1.11.28
+Django==2.2.12
 # This might not be used anymore.
 django-filter==0.11.0
-djangorestframework==3.8.2
+djangorestframework==3.11.0
 drf-yasg==1.17.1
 Markdown==2.6.5
 mysqlclient==1.4.6
@@ -10,17 +10,13 @@ numpy==1.18.1
 wheel==0.24.0
 uWSGI==2.0.12
 -e git+http://github.com/jhuapl-boss/drf-oidc-auth.git#egg=drf-oidc-auth
--e git+http://github.com/jhuapl-boss/django-oidc.git#egg=django-oidc
--e git+http://github.com/jhuapl-boss/boss-oidc.git#egg=boss-oidc
 
-# django-guardian 1.5.0 get this error on endpoint when trying to make migrations:
-# File "/usr/local/lib/python3.5/site-packages/guardian/admin.py", line 11, in <module>'}}
-#    from django.urls import reverse'}}
-#    "ImportError: No module named 'django.urls'"}}
-# Pinning at 1.4.9 for now.
-django-guardian==1.4.9
+mozilla-django-oidc==1.2.3
+datapunt_keycloak_oidc==0.5
 
-django-cors-headers==2.5.0
+django-guardian==2.2.0
+
+django-cors-headers==3.2.1
 django-bootstrap-form
 django-redis
 git+https://github.com/jhuapl-boss/django-nose2.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,12 @@
 boto3>=1.4.0
-Django==1.9.1
+Django==1.11.28
+# This might not be used anymore.
 django-filter==0.11.0
-djangorestframework==3.3.1
-django-rest-swagger==0.3.5
+djangorestframework==3.8.2
+drf-yasg==1.17.1
 Markdown==2.6.5
-mysqlclient==1.3.7
-numpy==1.11.1
+mysqlclient==1.4.6
+numpy==1.18.1
 wheel==0.24.0
 uWSGI==2.0.12
 -e git+http://github.com/jhuapl-boss/drf-oidc-auth.git#egg=drf-oidc-auth
@@ -19,10 +20,7 @@ uWSGI==2.0.12
 # Pinning at 1.4.9 for now.
 django-guardian==1.4.9
 
-# django-cors-headers 2.5.0 has removed support for django 1.8, 1.9 and 1.10.
-#    Using it causes: ImportError: cannot import name 'MiddlewareMixin' in
-#    uwsgi logs and fails to work properly.
-django-cors-headers==2.4.1
+django-cors-headers==2.5.0
 django-bootstrap-form
 django-redis
 git+https://github.com/jhuapl-boss/django-nose2.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,6 @@ django-cors-headers==3.2.1
 django-bootstrap-form
 django-redis
 git+https://github.com/jhuapl-boss/django-nose2.git
+
+# Intern 1.0.0 uses Python language features incompatible with Python 3.5.
+intern<1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3>=1.4.0
-Django==2.2.12
+Django==2.2.13
 # This might not be used anymore.
 django-filter==0.11.0
 djangorestframework==3.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,10 +9,11 @@ mysqlclient==1.4.6
 numpy==1.18.1
 wheel==0.24.0
 uWSGI==2.0.12
--e git+http://github.com/jhuapl-boss/drf-oidc-auth.git#egg=drf-oidc-auth
+
+drf-oidc-auth==0.10.0
+-e git+http://github.com/jhuapl-boss/boss-oidc.git#egg=boss-oidc
 
 mozilla-django-oidc==1.2.3
-datapunt_keycloak_oidc==0.5
 
 django-guardian==2.2.0
 


### PR DESCRIPTION
Upgrade to Django 2.2.13.

* Removed abandoned `django-oidc` dependency in favor of `mozilla-django-oidc`
* Removed use of our fork of `drf-oidc-auth` now that the original repo uses thread locking
* Redirect to login page after logging out

Related PRs:
https://github.com/jhuapl-boss/boss-tools/pull/37
https://github.com/jhuapl-boss/boss-manage/pull/82
