### PR TITLE
Add userfacing error when downsample kickoff fails

### DIFF
--- a/django/mgmt/static/js/downsample.js
+++ b/django/mgmt/static/js/downsample.js
@@ -115,6 +115,10 @@ function downsample_ajax(collection, experiment, channel, type, data){
                 raise_ajax_error(response);
                 $("#downsample-btn").removeClass('disabled');
             },
+            409: function (response) {
+                raise_ajax_error(response);
+                $("#downsample-btn").removeClass('disabled');
+            },
             500: function (response) {
                 raise_ajax_error(response);
                 $("#downsample-btn").removeClass('disabled');


### PR DESCRIPTION
When kicking off a downsample and it fails due to one already running, the error thrown by the web console returns a status code 409. This error was previously uncaught. This PR catches that error and presents it to the user.