### PR TITLE
URL Fix

### DIFF
--- a/django/mgmt/static/js/collections.js
+++ b/django/mgmt/static/js/collections.js
@@ -1,5 +1,5 @@
 function collection_handler(response) {
-    var detail_base_url = window.location.href + "/";
+    var detail_base_url = API_ROOT + "mgmt/resources/";
     var delete_function = "delete_collection";
     var delete_base_url = API_ROOT + "collection/";
 
@@ -17,7 +17,7 @@ function coord_handler(response) {
 
 function experiment_handler(response) {
     var resources = get_resource_names();
-    var detail_base_url = window.location.href + "/";
+    var detail_base_url = API_ROOT + "mgmt/resources/" + resources[0] + "/";
     var delete_function = "delete_experiment";
     var delete_base_url = API_ROOT + "collection/" + resources[0] + "/experiment/";
 

--- a/django/mgmt/static/js/downsample.js
+++ b/django/mgmt/static/js/downsample.js
@@ -118,6 +118,10 @@ function downsample_ajax(collection, experiment, channel, type, data){
             500: function (response) {
                 raise_ajax_error(response);
                 $("#downsample-btn").removeClass('disabled');
+            },
+            409: function (response){
+                raise_ajax_error(response);
+                $("#downsample-btn").removeClass('disabled');
             }
         }
     });

--- a/django/mgmt/static/js/downsample.js
+++ b/django/mgmt/static/js/downsample.js
@@ -118,10 +118,6 @@ function downsample_ajax(collection, experiment, channel, type, data){
             500: function (response) {
                 raise_ajax_error(response);
                 $("#downsample-btn").removeClass('disabled');
-            },
-            409: function (response){
-                raise_ajax_error(response);
-                $("#downsample-btn").removeClass('disabled');
             }
         }
     });

--- a/django/mgmt/static/js/experiments.js
+++ b/django/mgmt/static/js/experiments.js
@@ -1,6 +1,6 @@
 function channel_handler(response) {
     var resources = get_resource_names();
-    var detail_base_url = window.location.href + "/";
+    var detail_base_url = API_ROOT + "mgmt/resources/" + resources[0] + "/" + resources[1] + "/";
     var delete_function = "delete_channel";
     var delete_base_url = API_ROOT + "collection/" + resources[0] + "/experiment/" + resources[1] + "/channel/";
     var neuroglancer_url = "https://neuroglancer.theboss.io/#!{'layers':{'" + resources[1] + "':{'source':'boss://https://" + window.location.host + "/" + resources[0] + "/" + resources[1] + "/";


### PR DESCRIPTION
Fixes error where a trailing slash at the end of a resource link such as:

https://api.bossdb.io/v1/mgmt/resources/wilson2019/ 

Will break all "detail" links on the experiment or channel table. 