### PR TITLE
Block API token request for public-access user.

### DIFF
--- a/django/mgmt/test/test_views.py
+++ b/django/mgmt/test/test_views.py
@@ -1,0 +1,33 @@
+# Copyright 2020 The Johns Hopkins University Applied Physics Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from rest_framework.test import APITestCase
+from django.contrib.auth.models import User
+from django.conf import settings
+from mgmt.views import PUBLIC_ACCESS_USERNAME
+
+version = settings.BOSS_VERSION
+
+class TestMgmtView(APITestCase):
+    def test_public_access_user_token_protected(self):
+        """Do not allow change of the public-access token."""
+        publicuser = User.objects.create_user(username=PUBLIC_ACCESS_USERNAME)
+        self.client.force_login(publicuser)
+        self.client.force_authenticate(user=publicuser)
+
+        url = f'/{version}/mgmt/token/'
+        actual = self.client.post(url)
+
+        self.assertEqual(403, actual.status_code)

--- a/django/mgmt/tests.py
+++ b/django/mgmt/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/django/mgmt/views.py
+++ b/django/mgmt/views.py
@@ -21,6 +21,8 @@ from .models import SystemNotice, BlogPost
 # import as to deconflict with our Token class
 from rest_framework.authtoken.models import Token as TokenModel
 
+# User name used for anonymous logins.
+PUBLIC_ACCESS_USERNAME = 'public-access'
 
 # DP NOTE: If a form fails validation in the post() method, then
 #          the populated form is passed to the get() method to
@@ -211,6 +213,8 @@ class Token(LoginRequiredMixin, View):
 
     def post(self, request):
         try:
+            if request.user.username == PUBLIC_ACCESS_USERNAME:
+                return HttpResponse(status=403, reason=f"Changing {PUBLIC_ACCESS_USERNAME}'s token forbidden")
             token = TokenModel.objects.get(user=request.user)
             token.delete()
         except:


### PR DESCRIPTION
Don't let anyone revoke or change the token for the public-access user
via the API.  Returns a 403 response for this request.

This is currently branched off of the ubuntu-20.04 branch but could probably be cherry-picked onto integration if we want to deploy this sooner. In addition to unit testing, I manually tested it on my endpoint.