### PR TITLE
added missing app_name for urls_to_black

### DIFF
--- a/django/bossspatialdb/urls_to_black.py
+++ b/django/bossspatialdb/urls_to_black.py
@@ -16,6 +16,7 @@ from django.conf.urls import url
 from django.contrib.auth.decorators import login_required
 from . import views
 
+app_name = 'bossspatialdb'
 urlpatterns = [
 
     # Url to handle cutout_to_black with a collection, experiment, channel/annotation project and  range time


### PR DESCRIPTION
Update to change urls_to_black to have new app_name required by newer version of Django.  
