### PR TITLE
Daily metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ target/
 *.swp
 
 .idea
+.vscode

--- a/django/boss/throttling.py
+++ b/django/boss/throttling.py
@@ -64,7 +64,14 @@ def parse_limit(metric,mtype):
 
     return int(val) # Returning an int, as redis works with ints
 
-def _redisKeyNamePattern(metricName)
+def _redisKeyNamePattern(metricName):
+    """Get a redis search pattern to match metrics by name
+
+    Args: 
+        metricName (str): The name of the metric
+    
+    Returns: format string that can be used as a search pattern
+    """
     return "{}*".format(metricName)
 
 class RedisMetricKey(object):
@@ -120,7 +127,7 @@ class RedisMetrics(object):
                                           boss_config['aws']['cache-throttle-db'])
         else:
             self.conn = None
-   def getMetrics(self, metricName):
+    def get_metrics(self, metricName):
         """Get the metrics that match name
         Args: 
            metricName(str): name of metric
@@ -129,9 +136,9 @@ class RedisMetrics(object):
         """
         if self.conn in None:
            return None
-        return k.decode('utf8') for k in self.metrics.conn.keys(pattern=_redisKeyNamePattern(metricName))]
+        return [k.decode('utf8') for k in self.metrics.conn.keys(pattern=_redisKeyNamePattern(metricName))]
 
-   def get_metric(self, metricKey):
+    def get_metric(self, metricKey):
         """Get the current metric value for the given object
 
         Args:

--- a/django/boss/throttling.py
+++ b/django/boss/throttling.py
@@ -328,7 +328,7 @@ class BossThrottle(object):
         Raises:
             Throttle: If the system is throttled
         """
-        current = self.data.get_metric('system')
+        current = self.data.get_metric('system', theDate)
         max = self.limits.lookup_system()
 
         if max and current > max:

--- a/django/boss/throttling.py
+++ b/django/boss/throttling.py
@@ -134,9 +134,9 @@ class RedisMetrics(object):
 
         Returns: list of metricKey objects
         """
-        if self.conn in None:
+        if not self.conn:
            return None
-        return [k.decode('utf8') for k in self.metrics.conn.keys(pattern=_redisKeyNamePattern(metricName))]
+        return [k.decode('utf8') for k in self.conn.keys(pattern=_redisKeyNamePattern(metricName))]
 
     def get_metric(self, metricKey):
         """Get the current metric value for the given object

--- a/django/boss/urls.py
+++ b/django/boss/urls.py
@@ -54,6 +54,7 @@ urlpatterns = [
     url(r'^docs/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     url(r'^ping/', views.Ping.as_view()),
     url(r'^token/', views.Token.as_view()),
+    url(r'^metric/', views.Metric.as_view()),
 
     # deprecated urls
     url(r'^v0.1/', views.Unsupported.as_view()),

--- a/django/boss/views.py
+++ b/django/boss/views.py
@@ -159,13 +159,15 @@ class Metric(LoginRequiredMixin, APIView):
     def getValues(self,keys):
         dates = { k.split("_")[-2] : int(self.metrics.conn.get(k).decode('utf8')) for k in keys }
         total = sum([v for v in dates.values()])
-        return { 'dates':dates, 'total':total }
+        return { 'dates':dates, 'total':total, 'units': keys[0].split("_")[-1] }
         
     def getMetrics(self,metric):
         keys = [k.decode('utf8') for k in self.metrics.conn.keys(pattern="{}*".format(metric))]
-        ingress = [k for k in keys if '_ingress' in k]
-        egress = [k for k in keys if '_egress' in k]
-        return {'metric': metric, 'egress':self.getValues(egress) , 'ingress': self.getValues(ingress)}
+        types = set([k.split("_")[-3] for k in keys])
+        result = {'metric':metric}
+        for t in types:
+            result[t] = self.getValues([k for k in keys if t in k])
+        return result
 
     def get(self, request):
         if self.metrics.conn == None:

--- a/django/boss/views.py
+++ b/django/boss/views.py
@@ -157,8 +157,8 @@ class Metric(LoginRequiredMixin, APIView):
         return User.objects.get(username=ADMIN_USER)
 
     def getValues(self,keys):
-        dates = { k.split("_")[-2] : self.metrics.conn.get(k).decode('utf8') for k in keys }
-        total = sum([int(v) for v in dates.values()])
+        dates = { k.split("_")[-2] : int(self.metrics.conn.get(k).decode('utf8')) for k in keys }
+        total = sum([v for v in dates.values()])
         return { 'dates':dates, 'total':total }
         
     def getMetrics(self,metric):

--- a/django/bossingest/test/setup.py
+++ b/django/bossingest/test/setup.py
@@ -146,15 +146,15 @@ class SetupTests(object):
         data['ingest_job'] = {}
         data['ingest_job']['resolution'] = 0
         data['ingest_job']['extent'] = {}
-        data['ingest_job']['extent']['x'] = [0, 2048]
-        data['ingest_job']['extent']['y'] = [0, 2048]
-        data['ingest_job']['extent']['z'] = [0, 40]
+        data['ingest_job']['extent']['x'] = [0, 4096]
+        data['ingest_job']['extent']['y'] = [0, 4096]
+        data['ingest_job']['extent']['z'] = [0, 64]
         data['ingest_job']['extent']['t'] = [0, 1]
 
         data['ingest_job']['chunk_size'] = {}
-        data['ingest_job']['chunk_size']['x'] = 1024
-        data['ingest_job']['chunk_size']['y'] = 1024
-        data['ingest_job']['chunk_size']['z'] = 64
+        data['ingest_job']['chunk_size']['x'] = 512
+        data['ingest_job']['chunk_size']['y'] = 512
+        data['ingest_job']['chunk_size']['z'] = 16
 
         data['ingest_job']['ingest_type'] = 'volumetric'
 

--- a/django/bossingest/views.py
+++ b/django/bossingest/views.py
@@ -276,6 +276,8 @@ class IngestJobView(IngestServiceView):
                * 1 # the cost per lambda
                ) # Calculating the cost of the lambda invocations
 
+        BossThrottle().check('ingest','compute',request.user,cost,'lambdas')
+
         boss_config = bossutils.configuration.BossConfig()
         dimensions = [
             {'Name': 'User', 'Value': request.user.username},
@@ -526,4 +528,3 @@ class IngestJobStatusView(IngestServiceView):
                 return err.to_http()
         except Exception as err:
             return BossError("{}".format(err), ErrorCodes.BOSS_SYSTEM_ERROR).to_http()
-

--- a/django/bossspatialdb/views.py
+++ b/django/bossspatialdb/views.py
@@ -533,17 +533,17 @@ class Downsample(APIView):
                 * get_cubes('y', 512)
                 * get_cubes('z', 16)
                 / 4 # Number of cubes for a downsampled volume
-                * 0.75 # Assume the frame is only 75% filled
-                * 2 # 1 for invoking a lambda
-                    # 1 for time it takes lambda to run
-                * 1.33 # Add 33% overhead for all other non-base resolution downsamples
+ #               * 0.75 # Assume the frame is only 75% filled
+#                * 2 # 1 for invoking a lambda
+#                    # 1 for time it takes lambda to run
+#                * 1.33 # Add 33% overhead for all other non-base resolution downsamples
                )
 
         log = bossLogger()
         log.info("Checking for throttling")
         BossThrottle().check('downsample','compute',
                              request.user,
-                             cost,'units')
+                             cost,'cuboids')
 
         dimensions = [
             {'Name': 'User', 'Value': request.user.username},

--- a/django/bossspatialdb/views.py
+++ b/django/bossspatialdb/views.py
@@ -132,9 +132,10 @@ class Cutout(APIView):
                / 8
                ) # Calculating the number of bytes
 
-        BossThrottle().check('cutout_egress',
+        # seprate direction of movement from api and provide units of metric
+        BossThrottle().check('cutout','egress',
                              request.user,
-                             cost)
+                             cost,'bytes')
 
         boss_config = bossutils.configuration.BossConfig()
         dimensions = [
@@ -243,9 +244,9 @@ class Cutout(APIView):
                / 8
                ) # Calculating the number of bytes
 
-        BossThrottle().check('cutout_ingress',
+        BossThrottle().check('cutout','ingress',
                              request.user,
-                             cost)
+                             cost,'bytes')
 
         boss_config = bossutils.configuration.BossConfig()
         dimensions = [
@@ -537,6 +538,12 @@ class Downsample(APIView):
                     # 1 for time it takes lambda to run
                 * 1.33 # Add 33% overhead for all other non-base resolution downsamples
                )
+
+        log = bossLogger()
+        log.info("Checking for throttling")
+        BossThrottle().check('downsample','compute',
+                             request.user,
+                             cost,'units')
 
         dimensions = [
             {'Name': 'User', 'Value': request.user.username},

--- a/django/bosstiles/views.py
+++ b/django/bosstiles/views.py
@@ -102,9 +102,9 @@ class CutoutTile(APIView):
                / 8
                ) # Calculating the number of bytes
 
-        BossThrottle().check('image_egress',
+        BossThrottle().check('image','egress',
                              request.user,
-                             cost)
+                             cost,'bytes')
 
         boss_config = bossutils.configuration.BossConfig()
         dimensions = [
@@ -235,9 +235,9 @@ class Tile(APIView):
                / 8
                ) # Calculating the number of bytes
 
-        BossThrottle().check('tile_egress',
+        BossThrottle().check('tile','egress',
                              request.user,
-                             cost)
+                             cost,'bytes')
 
         boss_config = bossutils.configuration.BossConfig()
         dimensions = [


### PR DESCRIPTION
New feature and bug fixes for metrics. Redis keys for each metric are encoded with a date to allow tracking of daily usage for the last N days. The default is 30 days. A new API has been added to check the metrics.

Related to https://github.com/jhuapl-boss/boss-manage/pull/87