### PR TITLE
Keycloak 11.0.0

### DIFF
--- a/django/boss/authentication.py
+++ b/django/boss/authentication.py
@@ -17,7 +17,7 @@ from rest_framework.authentication import TokenAuthentication as DRFTokenAuthent
 from oidc_auth.util import cache
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings as django_settings
-from bossoidc.models import Keycloak as KeycloakModel
+from bossoidc2.models import Keycloak as KeycloakModel
 from bossutils.keycloak import KeyCloakClient
 
 DRF_KC_TIMEOUT = getattr(django_settings, 'DRF_KC_TIMEOUT', 60 * 5) # 5 Minutes

--- a/django/boss/settings/keycloak.py
+++ b/django/boss/settings/keycloak.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from .mysql import *
-from bossoidc.settings import BOSSOIDC_LOGIN_URL, BOSSOIDC_LOGOUT_URL
+from bossoidc2.settings import BOSSOIDC_LOGIN_URL, BOSSOIDC_LOGOUT_URL
 
 """
 Run Boss with a local Keycloak instance for testing.
@@ -30,7 +30,7 @@ KEYCLOAK_ADMIN_PASSWORD = 'bossadmin'
 LOGIN_URL = BOSSOIDC_LOGIN_URL
 LOGOUT_URL = BOSSOIDC_LOGOUT_URL
 
-INSTALLED_APPS.append("bossoidc")
+INSTALLED_APPS.append("bossoidc2")
 INSTALLED_APPS.append("mozilla_django_oidc")
 INSTALLED_APPS.append("rest_framework.authtoken")
 
@@ -41,7 +41,7 @@ REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] = (
     'oidc_auth.authentication.BearerTokenAuthentication',
 )
 
-AUTHENTICATION_BACKENDS.insert(1, 'bossoidc.backend.OpenIdConnectBackend') 
+AUTHENTICATION_BACKENDS.insert(1, 'bossoidc2.backend.OpenIdConnectBackend') 
 
 auth_uri = 'http://localhost:8080/auth/realms/BOSS'
 client_id = 'endpoint'
@@ -69,5 +69,5 @@ OIDC_VERIFY_SSL = False
 
 LOAD_USER_ROLES = 'bosscore.privileges.load_user_roles'
 
-from bossoidc.settings import configure_oidc
+from bossoidc2.settings import configure_oidc
 configure_oidc(auth_uri, client_id, public_uri)

--- a/django/boss/settings/keycloak.py
+++ b/django/boss/settings/keycloak.py
@@ -21,7 +21,6 @@ Run Boss with a local Keycloak instance for testing.
 
 # These are variables used for testing.  Don't copy these to production.py!
 LOCAL_KEYCLOAK_TESTING = True
-KEYCLOAK_ADMIN_USER = 'bossadmin'
 KEYCLOAK_ADMIN_PASSWORD = 'bossadmin'
 
 
@@ -55,9 +54,16 @@ LOGIN_REDIRECT_URL = public_uri + 'v1/mgmt'
 LOGOUT_REDIRECT_URL = auth_uri + '/protocol/openid-connect/logout?redirect_uri=' + public_uri
 OIDC_RP_CLIENT_ID = client_id
 OIDC_RP_CLIENT_SECRET = ''
-OIDC_RP_SCOPES = 'sub preferred_username'
+OIDC_RP_SCOPES = 'email openid profile'
 OIDC_RP_SIGN_ALGO = 'RS256'
 OIDC_OP_JWKS_ENDPOINT = auth_uri + '/protocol/openid-connect/certs'
+
+# Fields to look for in the userinfo returned from Keycloak
+OIDC_CLAIMS_VERIFICATION = 'preferred_username sub email'
+
+# Allow this user to not have an email address during OIDC claims verification.
+KEYCLOAK_ADMIN_USER = 'bossadmin'
+
 # No SSL when running locally during development.
 OIDC_VERIFY_SSL = False
 

--- a/django/boss/settings/production.py
+++ b/django/boss/settings/production.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from .base import *
-from bossoidc.settings import BOSSOIDC_LOGIN_URL, BOSSOIDC_LOGOUT_URL
+from bossoidc2.settings import BOSSOIDC_LOGIN_URL, BOSSOIDC_LOGOUT_URL
 
 """
 Run the boss in production.
@@ -63,7 +63,7 @@ if config['aws']['cache-session'] != '':
 LOGIN_URL = BOSSOIDC_LOGIN_URL
 LOGOUT_URL = BOSSOIDC_LOGOUT_URL
 
-INSTALLED_APPS.append("bossoidc")
+INSTALLED_APPS.append("bossoidc2")
 INSTALLED_APPS.append("mozilla_django_oidc")
 INSTALLED_APPS.append("rest_framework.authtoken")
 
@@ -74,7 +74,7 @@ REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] = (
     'oidc_auth.authentication.BearerTokenAuthentication',
 )
 
-AUTHENTICATION_BACKENDS.insert(1, 'bossoidc.backend.OpenIdConnectBackend') 
+AUTHENTICATION_BACKENDS.insert(1, 'bossoidc2.backend.OpenIdConnectBackend') 
 
 auth_uri = vault.read('secret/endpoint/auth', 'url')
 client_id = vault.read('secret/endpoint/auth', 'client_id')
@@ -99,7 +99,7 @@ KEYCLOAK_ADMIN_USER = 'bossadmin'
 
 LOAD_USER_ROLES = 'bosscore.privileges.load_user_roles'
 
-from bossoidc.settings import configure_oidc
+from bossoidc2.settings import configure_oidc
 configure_oidc(auth_uri, client_id, public_uri)
 
 # Load params for spatialDB once during settings.py

--- a/django/boss/settings/production.py
+++ b/django/boss/settings/production.py
@@ -1,4 +1,4 @@
-# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
+# Copyright 2020 The Johns Hopkins University Applied Physics Laboratory
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -87,10 +87,15 @@ LOGIN_REDIRECT_URL = public_uri + 'v1/mgmt'
 LOGOUT_REDIRECT_URL = auth_uri + '/protocol/openid-connect/logout?redirect_uri=' + public_uri
 OIDC_RP_CLIENT_ID = client_id
 OIDC_RP_CLIENT_SECRET = ''
-OIDC_RP_SCOPES = 'sub preferred_username'
+OIDC_RP_SCOPES = 'email openid profile'
 OIDC_RP_SIGN_ALGO = 'RS256'
 OIDC_OP_JWKS_ENDPOINT = auth_uri + '/protocol/openid-connect/certs'
 OIDC_VERIFY_SSL = not (config['auth']['OIDC_VERIFY_SSL'] in ['False', 'false'])
+# Fields to look for in the userinfo returned from Keycloak
+OIDC_CLAIMS_VERIFICATION = 'preferred_username sub email'
+
+# Allow this user to not have an email address during OIDC claims verification.
+KEYCLOAK_ADMIN_USER = 'bossadmin'
 
 LOAD_USER_ROLES = 'bosscore.privileges.load_user_roles'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3>=1.4.0
-Django==2.2.13
+Django==2.2.16
 # This might not be used anymore.
-django-filter==0.11.0
+#django-filter==0.11.0
 djangorestframework==3.11.0
 drf-yasg==1.17.1
 Markdown==2.6.5
@@ -12,8 +12,8 @@ uWSGI==2.0.19.1
 
 drf-oidc-auth==0.10.0
 
-# ToDo: update this to point at new repo for boss-oidc.
--e git+https://github.com/jhuapl-boss/boss-oidc.git@keycloak-11.0.0#egg=boss-oidc
+# bossoidc2 on v2.0.0.
+git+https://github.com/jhuapl-boss/boss-oidc2.git@v2.0.0#egg=boss-oidc2
 
 mozilla-django-oidc==1.2.3
 
@@ -24,5 +24,4 @@ django-bootstrap-form
 django-redis
 git+https://github.com/jhuapl-boss/django-nose2.git
 
-# Intern 1.0.0 uses Python language features incompatible with Python 3.5.
-intern<1.0
+intern

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,9 @@ wheel==0.24.0
 uWSGI==2.0.19.1
 
 drf-oidc-auth==0.10.0
--e git+https://github.com/jhuapl-boss/boss-oidc.git@mozilla#egg=boss-oidc
+
+# ToDo: update this to point at new repo for boss-oidc.
+-e git+https://github.com/jhuapl-boss/boss-oidc.git@keycloak-11.0.0#egg=boss-oidc
 
 mozilla-django-oidc==1.2.3
 


### PR DESCRIPTION
Upgrade Boss to use Keycloak 11.0.0.

Upgrade Django to 2.2.16
Remove django-filter package
Switch to boss-oidc2 package

#### Related PRs:
https://github.com/jhuapl-boss/boss-manage/pull/88
https://github.com/jhuapl-boss/neuroglancer/pull/5