### PR TITLE
Prevent 500 error when there's a failed downsample.

### DIFF
--- a/django/bosscore/models.py
+++ b/django/bosscore/models.py
@@ -1,4 +1,4 @@
-# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
+# Copyright 2020 The Johns Hopkins University Applied Physics Laboratory
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,6 +33,8 @@ class Collection(models.Model):
     description = models.CharField(max_length=4096, blank=True)
     creator = models.ForeignKey('auth.User', on_delete=models.CASCADE, related_name='collections')
     to_be_deleted = models.DateTimeField(null=True, blank=True)
+
+    # ToDo: replace with constants.
     DELETED_STATUS_CHOICES = (
         ('started', 'STARTED'),
         ('finished', 'FINISHED'),
@@ -80,6 +82,7 @@ class CoordinateFrame(models.Model):
     y_voxel_size = models.FloatField()
     z_voxel_size = models.FloatField()
 
+    # ToDo: replace with constants.
     VOXEL_UNIT_CHOICES = (
         ('nanometers', 'NANOMETERS'),
         ('micrometers', 'MICROMETERS'),
@@ -96,6 +99,7 @@ class CoordinateFrame(models.Model):
     # )
     # time_step_unit = models.CharField(choices=TIMESTEP_UNIT_CHOICES, max_length=100, blank=True, null=True)
     to_be_deleted = models.DateTimeField(null=True, blank=True)
+    # ToDo: replace with constants.
     DELETED_STATUS_CHOICES = (
         ('started', 'STARTED'),
         ('finished', 'FINISHED'),
@@ -135,6 +139,7 @@ class Experiment(models.Model):
     coord_frame = models.ForeignKey(CoordinateFrame, related_name='exps', on_delete=models.PROTECT)
     num_hierarchy_levels = models.IntegerField(default=1)
 
+    # ToDo: replace with constants.
     HIERARCHY_METHOD_CHOICES = (
         ('anisotropic', 'ANISOTROPIC'),
         ('isotropic', 'ISOTROPIC'),
@@ -142,6 +147,7 @@ class Experiment(models.Model):
     hierarchy_method = models.CharField(choices=HIERARCHY_METHOD_CHOICES, max_length=100, default='anisotropic')
     num_time_samples = models.IntegerField(default=1)
     time_step = models.IntegerField(blank=True, null=True)
+    # ToDo: replace with constants.
     TIMESTEP_UNIT_CHOICES = (
         ('nanoseconds', 'NANOSECONDS'),
         ('microseconds', 'MICROSECONDS'),
@@ -150,6 +156,7 @@ class Experiment(models.Model):
     )
     time_step_unit = models.CharField(choices=TIMESTEP_UNIT_CHOICES, max_length=100, blank=True, null=True)
     to_be_deleted = models.DateTimeField(null=True, blank=True)
+    # ToDo: replace with constants.
     DELETED_STATUS_CHOICES = (
         ('started', 'STARTED'),
         ('finished', 'FINISHED'),
@@ -193,6 +200,7 @@ class Channel(models.Model):
     )
     type = models.CharField(choices=TYPE_CHOICES, max_length=100)
 
+    # ToDo: replace with constants.
     DATATYPE_CHOICES = (
         ('uint8', 'UINT8'),
         ('uint16', 'UINT16'),
@@ -203,6 +211,7 @@ class Channel(models.Model):
     sources = models.ManyToManyField('self', through='Source', symmetrical=False, related_name='derived', blank=True)
     related = models.ManyToManyField('self', related_name='related', blank=True)
     to_be_deleted = models.DateTimeField(null=True, blank=True)
+    # ToDo: replace with constants.
     DELETED_STATUS_CHOICES = (
         ('started', 'STARTED'),
         ('finished', 'FINISHED'),
@@ -210,13 +219,20 @@ class Channel(models.Model):
     )
     deleted_status = models.CharField(choices=DELETED_STATUS_CHOICES, max_length=100, null=True, blank=True)
 
-    DOWNSAMPLE_METHOD_CHOICES = (
-        ('NOT_DOWNSAMPLED', 'Not Downsampled'),
-        ('IN_PROGRESS', 'In Progress'),
-        ('DOWNSAMPLED', 'Downsampled'),
-        ('FAILED', 'Failed'),
+    class DownsampleStatus:
+        """String values are actual values stored in DB."""
+        NOT_DOWNSAMPLED = 'NOT_DOWNSAMPLED'
+        IN_PROGRESS = 'IN_PROGRESS'
+        DOWNSAMPLED = 'DOWNSAMPLED'
+        FAILED = 'FAILED'
+
+    DOWNSAMPLE_STATUS_CHOICES = (
+        (DownsampleStatus.NOT_DOWNSAMPLED, 'Not Downsampled'),
+        (DownsampleStatus.IN_PROGRESS, 'In Progress'),
+        (DownsampleStatus.DOWNSAMPLED, 'Downsampled'),
+        (DownsampleStatus.FAILED, 'Failed'),
     )
-    downsample_status = models.CharField(choices=DOWNSAMPLE_METHOD_CHOICES, default="NOT_DOWNSAMPLED", max_length=100)
+    downsample_status = models.CharField(choices=DOWNSAMPLE_STATUS_CHOICES, default=DownsampleStatus.NOT_DOWNSAMPLED, max_length=100)
     downsample_arn = models.CharField(max_length=4096, blank=True, null=True)
 
     class Meta:
@@ -293,6 +309,7 @@ class BossRole(models.Model):
     Map user's to roles.
     """
     user = models.ForeignKey('auth.User', related_name='Role', on_delete=models.CASCADE)
+    # ToDo: replace with constants.
     DATATYPE_CHOICES = (
         ('admin', 'ADMIN'),
         ('user-manager', 'USER-MANAGER'),

--- a/django/bossspatialdb/test/int_test_downsample_view.py
+++ b/django/bossspatialdb/test/int_test_downsample_view.py
@@ -21,6 +21,7 @@ from rest_framework import status
 from bossspatialdb.views import Downsample
 from bossspatialdb.test import DownsampleInterfaceViewMixin
 from bossspatialdb.views import Cutout
+from bosscore.models import Channel
 
 from bosscore.test.setup_db import DjangoSetupLayer
 
@@ -110,7 +111,7 @@ class TestIntegrationDownsampleInterfaceView(DownsampleInterfaceViewMixin, APITe
                                         channel='channel1').render()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["num_hierarchy_levels"], 5)
-        self.assertEqual(response.data["status"], "IN_PROGRESS")
+        self.assertEqual(response.data["status"], Channel.DownsampleStatus.IN_PROGRESS)
 
         for _ in range(0, 30):
             # Make request
@@ -118,7 +119,7 @@ class TestIntegrationDownsampleInterfaceView(DownsampleInterfaceViewMixin, APITe
                                             channel='channel1').render()
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-            if response.data["status"] != "IN_PROGRESS":
+            if response.data["status"] != Channel.DownsampleStatus.IN_PROGRESS:
                 break
 
             time.sleep(2)
@@ -128,7 +129,7 @@ class TestIntegrationDownsampleInterfaceView(DownsampleInterfaceViewMixin, APITe
                                         channel='channel1').render()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["num_hierarchy_levels"], 5)
-        self.assertEqual(response.data["status"], "DOWNSAMPLED")
+        self.assertEqual(response.data["status"], Channel.DownsampleStatus.DOWNSAMPLED)
 
         # Get data at res 1 and verify it's non-zero
         request = factory.get('/' + version + '/cutout/col1/exp_ds_aniso/channel1/1/0:512/0:512/0:16/',
@@ -228,7 +229,7 @@ class TestIntegrationDownsampleInterfaceView(DownsampleInterfaceViewMixin, APITe
                                         channel='channel1').render()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["num_hierarchy_levels"], 5)
-        self.assertEqual(response.data["status"], "NOT_DOWNSAMPLED")
+        self.assertEqual(response.data["status"], Channel.DownsampleStatus.NOT_DOWNSAMPLED)
 
     def setUp(self):
         """ Copy params from the Layer setUpClass

--- a/django/bossspatialdb/test/test_downsample_view.py
+++ b/django/bossspatialdb/test/test_downsample_view.py
@@ -19,6 +19,7 @@ from rest_framework.test import force_authenticate
 from rest_framework import status
 
 from bossspatialdb.views import Downsample
+from bosscore.models import Channel
 
 from bosscore.test.setup_db import SetupTestDB
 from bosscore.error import BossError
@@ -56,7 +57,7 @@ class DownsampleInterfaceViewMixin(object):
         response = Downsample.as_view()(request, collection='col1', experiment='exp_iso', channel='channel1').render()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["num_hierarchy_levels"], 8)
-        self.assertEqual(response.data["status"], "NOT_DOWNSAMPLED")
+        self.assertEqual(response.data["status"], Channel.DownsampleStatus.NOT_DOWNSAMPLED)
         self.assertEqual(response.data["voxel_size"]['0'], [6.0, 6.0, 6.0])
         self.assertEqual(response.data["voxel_size"]['3'], [48.0, 48.0, 48.0])
         self.assertEqual(response.data["voxel_size"]['5'], [192.0, 192.0, 192.0])
@@ -80,7 +81,7 @@ class DownsampleInterfaceViewMixin(object):
         response = Downsample.as_view()(request, collection='col1', experiment='exp_iso', channel='channel1').render()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["num_hierarchy_levels"], 8)
-        self.assertEqual(response.data["status"], "NOT_DOWNSAMPLED")
+        self.assertEqual(response.data["status"], Channel.DownsampleStatus.NOT_DOWNSAMPLED)
         self.assertEqual(response.data["voxel_size"]['0'], [6.0, 6.0, 6.0])
         self.assertEqual(response.data["voxel_size"]['3'], [48.0, 48.0, 48.0])
         self.assertEqual(response.data["voxel_size"]['5'], [192.0, 192.0, 192.0])
@@ -104,7 +105,7 @@ class DownsampleInterfaceViewMixin(object):
         response = Downsample.as_view()(request, collection='col1', experiment='exp_iso', channel='channel1').render()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["num_hierarchy_levels"], 8)
-        self.assertEqual(response.data["status"], "NOT_DOWNSAMPLED")
+        self.assertEqual(response.data["status"], Channel.DownsampleStatus.NOT_DOWNSAMPLED)
         self.assertEqual(response.data["voxel_size"]['0'], [6.0, 6.0, 6.0])
         self.assertEqual(response.data["voxel_size"]['3'], [48.0, 48.0, 48.0])
         self.assertEqual(response.data["voxel_size"]['5'], [192.0, 192.0, 192.0])
@@ -128,7 +129,7 @@ class DownsampleInterfaceViewMixin(object):
         response = Downsample.as_view()(request, collection='col1', experiment='exp_aniso', channel='channel1').render()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["num_hierarchy_levels"], 8)
-        self.assertEqual(response.data["status"], "NOT_DOWNSAMPLED")
+        self.assertEqual(response.data["status"], Channel.DownsampleStatus.NOT_DOWNSAMPLED)
         self.assertEqual(response.data["voxel_size"]['0'], [4.0, 4.0, 35.0])
         self.assertEqual(response.data["voxel_size"]['3'], [32.0, 32.0, 35.0])
         self.assertEqual(response.data["voxel_size"]['5'], [128.0, 128.0, 35.0])
@@ -152,7 +153,7 @@ class DownsampleInterfaceViewMixin(object):
         response = Downsample.as_view()(request, collection='col1', experiment='exp_aniso', channel='channel1').render()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["num_hierarchy_levels"], 8)
-        self.assertEqual(response.data["status"], "NOT_DOWNSAMPLED")
+        self.assertEqual(response.data["status"], Channel.DownsampleStatus.NOT_DOWNSAMPLED)
         self.assertEqual(response.data["voxel_size"]['0'], [4.0, 4.0, 35.0])
         self.assertEqual(response.data["voxel_size"]['3'], [32.0, 32.0, 35.0])
         self.assertEqual(response.data["voxel_size"]['5'], [128.0, 128.0, 35.0])
@@ -176,7 +177,7 @@ class DownsampleInterfaceViewMixin(object):
         response = Downsample.as_view()(request, collection='col1', experiment='exp_aniso', channel='channel1').render()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["num_hierarchy_levels"], 8)
-        self.assertEqual(response.data["status"], "NOT_DOWNSAMPLED")
+        self.assertEqual(response.data["status"], Channel.DownsampleStatus.NOT_DOWNSAMPLED)
         self.assertEqual(response.data["voxel_size"]['0'], [4.0, 4.0, 35.0])
         self.assertEqual(response.data["voxel_size"]['3'], [32.0, 32.0, 35.0])
         self.assertEqual(response.data["voxel_size"]['5'], [128.0, 128.0, 140])
@@ -213,7 +214,7 @@ class DownsampleInterfaceViewMixin(object):
                                         channel='channel1').render()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["num_hierarchy_levels"], 5)
-        self.assertEqual(response.data["status"], "IN_PROGRESS")
+        self.assertEqual(response.data["status"], Channel.DownsampleStatus.IN_PROGRESS)
 
         # Cancel the downsample job
         request = factory.delete('/' + version + '/downsample/col1/exp_ds_aniso/channel1/',
@@ -237,7 +238,7 @@ class DownsampleInterfaceViewMixin(object):
         response = Downsample.as_view()(request, collection='col1', experiment='exp_ds_aniso',
                                         channel='channel1').render()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["status"], "NOT_DOWNSAMPLED")
+        self.assertEqual(response.data["status"], Channel.DownsampleStatus.NOT_DOWNSAMPLED)
 
         # Try to cancel the downsample job again, but it won't because in NOT_DOWNSAMPLED state
         request = factory.delete('/' + version + '/downsample/col1/exp_ds_aniso/channel1/',


### PR DESCRIPTION
Previously, if a downsample's step function failed, the DB would have
that channel marked as downsample in progress and hold the ARN of that
step function.  When a user tried to do a new downsample, an exception
would be thrown if that failed step function ARN no longer exists.

Now, if that exception is thrown, the channel's downsample status is
marked as failed and the ARN of that non-existent step function is
removed from the DB.

https://jira.xrcs.jhuapl.edu/browse/MICRONS-1651