### PR TITLE
Update Neuroglancer Link 

### DIFF
--- a/django/mgmt/static/js/experiments.js
+++ b/django/mgmt/static/js/experiments.js
@@ -3,7 +3,8 @@ function channel_handler(response) {
     var detail_base_url = API_ROOT + "mgmt/resources/" + resources[0] + "/" + resources[1] + "/";
     var delete_function = "delete_channel";
     var delete_base_url = API_ROOT + "collection/" + resources[0] + "/experiment/" + resources[1] + "/channel/";
-    var neuroglancer_url = "https://neuroglancer.theboss.io/#!{'layers':{'" + resources[1] + "':{'source':'boss://https://" + window.location.host + "/" + resources[0] + "/" + resources[1] + "/";
+    var neuroglancer_base_url = "https://neuroglancer." + window.location.host.split('.')[1] + ".io/"
+    var neuroglancer_url = neuroglancer_base_url + "#!{'layers':{'" + resources[1] + "':{'source':'boss://https://" + window.location.host + "/" + resources[0] + "/" + resources[1] + "/";
 
     return channel_resource_formatter(response, detail_base_url, delete_function, delete_base_url, neuroglancer_url);
 }


### PR DESCRIPTION
Configures neuroglancer button to use the neuroglancer that corresponds to the host. 

Production stack will use`neuroglancer.theboss.io`. 
Public stack will use `neuroglancer.bossdb.io`. 

NOTE: Dev stacks will not work. We are currently not hosting a dev neuroglancer bucket in thebossdev account. Referencing other neuroglancer buckets does not work due to the cross-site auth issue. I think we should stand up a neuroglancer instance under `neuroglancer.thebossdev.io`.