### PR TITLE
HTTP/2 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,8 @@ target/
 
 .idea
 .vscode
+
+# ignore certificate symlinks
+*.crt 
+*.key
+*.pem

--- a/boss_nginx.conf
+++ b/boss_nginx.conf
@@ -6,10 +6,14 @@ upstream django {
 
 # configuration of the server
 server {
-    # the port your site will be served on
-    listen      80 default_server;
+    # Listen to http2 port. All http requests will automatically be re-routed to http2 by loadbalancer.
+    # No IPv6 ports necessary. Subnet between loadbalancer and endpoint is in IPv4 only.
+    listen      443 ssl http2;
     charset     utf-8;
-
+    
+    include     snippets/self-signed.conf;
+    include     snippets/ssl-params.conf;   
+    
     # max upload size
     client_max_body_size 550M;   # Slightly larger than where API will return reasonable error message
 

--- a/self-signed.conf
+++ b/self-signed.conf
@@ -1,0 +1,2 @@
+ssl_certificate /etc/ssl/certs/nginx-selfsigned.crt;
+ssl_certificate_key /etc/ssl/private/nginx-selfsigned.key;

--- a/ssl-params.conf
+++ b/ssl-params.conf
@@ -1,0 +1,21 @@
+# from https://syslink.pl/cipherlist/
+# more instructions here https://www.digitalocean.com/community/tutorials/how-to-create-a-self-signed-ssl-certificate-for-nginx-in-ubuntu-18-04
+
+ssl_protocols TLSv1.2;
+ssl_prefer_server_ciphers on;
+ssl_dhparam /etc/nginx/dhparam.pem;
+ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384;
+ssl_ecdh_curve secp384r1; # Requires nginx >= 1.1.0
+ssl_session_timeout  10m;
+ssl_session_cache shared:SSL:10m;
+ssl_session_tickets off; # Requires nginx >= 1.5.9
+ssl_stapling on; # Requires nginx >= 1.3.7
+ssl_stapling_verify on; # Requires nginx => 1.3.7
+resolver 8.8.8.8 8.8.4.4 valid=300s;
+resolver_timeout 5s;
+# Disable strict transport security for now. You can uncomment the following
+# line if you understand the implications.
+# add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
+add_header X-Frame-Options DENY;
+add_header X-Content-Type-Options nosniff;
+add_header X-XSS-Protection "1; mode=block";


### PR DESCRIPTION
Add HTTP/2 support to the API through a self-signed certificate. **Certificate and key files will be distributed to developers through e-mail.** 

Change-log: 
- Sets listen port to 443 in the nginx config file.
- Adds snippet for ssl key and certificate file.
- Adds snippet for SSL configuration from https://syslink.pl/cipherlist/

Associated PR: https://github.com/jhuapl-boss/boss-manage/pull/95
Test results in above PR!