### PR TITLE
Public detailed info

### DIFF
--- a/django/bosscore/request.py
+++ b/django/bosscore/request.py
@@ -793,13 +793,13 @@ class BossRequest:
             self.bosskey(str) : String that represents the boss key for the current request
         """
         if self.service == 'cutout' or self.service == 'image' or self.service == 'tile'\
-                or self.service == 'boundingbox':
+                or self.service == 'boundingbox' or self.service == 'downsample':
             # TODO SH Hack added to allow us to quickly make channels public without logging in.
             # These are bossdb IDs.
             if self.channel.id in [1080, 1083]:
                 return
             perm = BossPermissionManager.check_data_permissions(self.user, self.channel, self.method)
-        elif self.service == 'downsample' or  self.service == 'ids':
+        elif self.service == 'ids':
             perm = BossPermissionManager.check_data_permissions(self.user, self.channel, self.method)
         elif self.service == 'meta':
             if self.collection and self.experiment and self.channel:

--- a/django/bosscore/request.py
+++ b/django/bosscore/request.py
@@ -796,7 +796,7 @@ class BossRequest:
                 or self.service == 'boundingbox' or self.service == 'downsample':
             # TODO SH Hack added to allow us to quickly make channels public without logging in.
             # These are bossdb IDs.
-            if self.channel.id in [1080, 1083]:
+            if self.channel.id in [1080, 1081, 1082, 1083]:
                 return
             perm = BossPermissionManager.check_data_permissions(self.user, self.channel, self.method)
         elif self.service == 'ids':

--- a/django/bosscore/serializers.py
+++ b/django/bosscore/serializers.py
@@ -261,9 +261,10 @@ class ExperimentReadSerializer(serializers.ModelSerializer):
 
     def get_channels_permissions(self, collection, experiment, cur_user):
         "return all channels that are not marked to be deleted and the user has read permissions on"
-
         collection_obj = Collection.objects.get(name=collection)
         experiment_obj = Experiment.objects.get(name=experiment, collection=collection_obj)
+        if experiment_obj.id in [176, 177]:
+            return self.get_channels(experiment_obj)
         channels = get_objects_for_user(cur_user, 'read', klass=Channel).filter(experiment=experiment_obj)
         channels = channels.exclude(to_be_deleted__isnull=False).values_list('name', flat=True)
         return channels
@@ -286,6 +287,8 @@ class CollectionSerializer(serializers.ModelSerializer):
     def get_experiments_permissions(self, collection, cur_user):
         "return all experiments that are not marked to be deleted and that the user has read permissions on"
         collection_obj = Collection.objects.get(name=collection)
+        if collection_obj.id in [108]:
+            return self.get_experiments(collection_obj)
         all_experiments = get_objects_for_user(cur_user, 'read', klass=Experiment).exclude(to_be_deleted__isnull=False)
         return all_experiments.filter(collection=collection_obj).values_list('name', flat=True)
 

--- a/django/bosscore/views/views_resource.py
+++ b/django/bosscore/views/views_resource.py
@@ -330,6 +330,8 @@ class ExperimentDetail(APIView):
                                          ErrorCodes.RESOURCE_MARKED_FOR_DELETION)
                 serializer = ExperimentReadSerializer(experiment_obj)
                 data = serializer.data
+                import logging
+                logging.Logger('boss').debug("request.user: " + str(type(request.user)))
                 data['channels'] = serializer.get_channels_permissions(collection_obj,experiment_obj,request.user)
                 return Response(data)
             else:
@@ -611,7 +613,7 @@ class ChannelDetail(APIView):
             # TODO SH Hack added to allow us to quickly make channels detail public without logging in.
             if channel_obj is None:
                 return BossResourceNotFoundError(channel)
-            if channel_obj.id in [1080, 1083] or request.user.has_perm("read", channel_obj):
+            if channel_obj.id in [1080, 1081, 1082, 1083] or request.user.has_perm("read", channel_obj):
                 if channel_obj.to_be_deleted is not None:
                     return BossHTTPError("Invalid Request. This Resource has been marked for deletion",
                                          ErrorCodes.RESOURCE_MARKED_FOR_DELETION)

--- a/django/bosscore/views/views_resource.py
+++ b/django/bosscore/views/views_resource.py
@@ -56,6 +56,7 @@ class CollectionDetail(APIView):
             collection_obj = Collection.objects.get(name=collection)
 
             # Check for permissions
+            # TODO SH Hack added to allow us to quickly make collection detail public without logging in.
             if self.collection_obj.id in [108] or request.user.has_perm("read", collection_obj):
                 if collection_obj.to_be_deleted is not None:
                     return BossHTTPError("Invalid Request. This Resource has been marked for deletion",
@@ -318,6 +319,7 @@ class ExperimentDetail(APIView):
             collection_obj = Collection.objects.get(name=collection)
             experiment_obj = Experiment.objects.get(name=experiment, collection=collection_obj)
             # Check for permissions
+            # TODO SH Hack added to allow us to quickly make experiment detail public without logging in.
             if self.experiment_obj.id in [176, 177] or request.user.has_perm("read", experiment_obj):
                 if experiment_obj.to_be_deleted is not None:
                     return BossHTTPError("Invalid Request. This Resource has been marked for deletion",
@@ -602,6 +604,7 @@ class ChannelDetail(APIView):
             channel_obj = Channel.objects.get(name=channel, experiment=experiment_obj)
 
             # Check for permissions
+            # TODO SH Hack added to allow us to quickly make channels detail public without logging in.
             if channel_obj.id in [1080, 1083] or request.user.has_perm("read", channel_obj):
                 if channel_obj.to_be_deleted is not None:
                     return BossHTTPError("Invalid Request. This Resource has been marked for deletion",

--- a/django/bosscore/views/views_resource.py
+++ b/django/bosscore/views/views_resource.py
@@ -57,7 +57,7 @@ class CollectionDetail(APIView):
 
             # Check for permissions
             # TODO SH Hack added to allow us to quickly make collection detail public without logging in.
-            if self.collection_obj.id in [108] or request.user.has_perm("read", collection_obj):
+            if collection_obj.id in [108] or request.user.has_perm("read", collection_obj):
                 if collection_obj.to_be_deleted is not None:
                     return BossHTTPError("Invalid Request. This Resource has been marked for deletion",
                                          ErrorCodes.RESOURCE_MARKED_FOR_DELETION)
@@ -320,7 +320,7 @@ class ExperimentDetail(APIView):
             experiment_obj = Experiment.objects.get(name=experiment, collection=collection_obj)
             # Check for permissions
             # TODO SH Hack added to allow us to quickly make experiment detail public without logging in.
-            if self.experiment_obj.id in [176, 177] or request.user.has_perm("read", experiment_obj):
+            if experiment_obj.id in [176, 177] or request.user.has_perm("read", experiment_obj):
                 if experiment_obj.to_be_deleted is not None:
                     return BossHTTPError("Invalid Request. This Resource has been marked for deletion",
                                          ErrorCodes.RESOURCE_MARKED_FOR_DELETION)

--- a/django/bosscore/views/views_resource.py
+++ b/django/bosscore/views/views_resource.py
@@ -56,7 +56,7 @@ class CollectionDetail(APIView):
             collection_obj = Collection.objects.get(name=collection)
 
             # Check for permissions
-            if request.user.has_perm("read", collection_obj):
+            if self.collection_obj.id in [108] or request.user.has_perm("read", collection_obj):
                 if collection_obj.to_be_deleted is not None:
                     return BossHTTPError("Invalid Request. This Resource has been marked for deletion",
                                          ErrorCodes.RESOURCE_MARKED_FOR_DELETION)
@@ -318,7 +318,7 @@ class ExperimentDetail(APIView):
             collection_obj = Collection.objects.get(name=collection)
             experiment_obj = Experiment.objects.get(name=experiment, collection=collection_obj)
             # Check for permissions
-            if request.user.has_perm("read", experiment_obj):
+            if self.experiment_obj.id in [176, 177] or request.user.has_perm("read", experiment_obj):
                 if experiment_obj.to_be_deleted is not None:
                     return BossHTTPError("Invalid Request. This Resource has been marked for deletion",
                                          ErrorCodes.RESOURCE_MARKED_FOR_DELETION)
@@ -602,7 +602,7 @@ class ChannelDetail(APIView):
             channel_obj = Channel.objects.get(name=channel, experiment=experiment_obj)
 
             # Check for permissions
-            if request.user.has_perm("read", channel_obj):
+            if channel_obj.id in [1080, 1083] or request.user.has_perm("read", channel_obj):
                 if channel_obj.to_be_deleted is not None:
                     return BossHTTPError("Invalid Request. This Resource has been marked for deletion",
                                          ErrorCodes.RESOURCE_MARKED_FOR_DELETION)

--- a/django/bosscore/views/views_resource.py
+++ b/django/bosscore/views/views_resource.py
@@ -57,6 +57,8 @@ class CollectionDetail(APIView):
 
             # Check for permissions
             # TODO SH Hack added to allow us to quickly make collection detail public without logging in.
+            if collection_obj is None:
+                return BossResourceNotFoundError(collection)
             if collection_obj.id in [108] or request.user.has_perm("read", collection_obj):
                 if collection_obj.to_be_deleted is not None:
                     return BossHTTPError("Invalid Request. This Resource has been marked for deletion",
@@ -320,6 +322,8 @@ class ExperimentDetail(APIView):
             experiment_obj = Experiment.objects.get(name=experiment, collection=collection_obj)
             # Check for permissions
             # TODO SH Hack added to allow us to quickly make experiment detail public without logging in.
+            if experiment_obj is None:
+                return BossResourceNotFoundError(experiment)
             if experiment_obj.id in [176, 177] or request.user.has_perm("read", experiment_obj):
                 if experiment_obj.to_be_deleted is not None:
                     return BossHTTPError("Invalid Request. This Resource has been marked for deletion",
@@ -605,6 +609,8 @@ class ChannelDetail(APIView):
 
             # Check for permissions
             # TODO SH Hack added to allow us to quickly make channels detail public without logging in.
+            if channel_obj is None:
+                return BossResourceNotFoundError(channel)
             if channel_obj.id in [1080, 1083] or request.user.has_perm("read", channel_obj):
                 if channel_obj.to_be_deleted is not None:
                     return BossHTTPError("Invalid Request. This Resource has been marked for deletion",


### PR DESCRIPTION
change it so public channels, experiments and collections can get detailed information without logging in.