### PR TITLE
Feature: cuboids_from_id

### DIFF
--- a/django/boss/urls.py
+++ b/django/boss/urls.py
@@ -91,6 +91,7 @@ urlpatterns = [
     url(r'^v1/reserve/', include('bossobject.urls.reserve_urls', namespace='v1')),
     url(r'^v1/ids/', include('bossobject.urls.ids_urls', namespace='v1')),
     url(r'^v1/boundingbox/', include('bossobject.urls.boundingbox_urls', namespace='v1')),
+    url(r'^v1/cuboidsfromid/', include('bossobject.urls.cuboidsfromid_urls', namespace='v1'))
 ]
 
 if 'djangooidc' in settings.INSTALLED_APPS:

--- a/django/bossobject/urls/cuboidsfromid_urls.py
+++ b/django/bossobject/urls/cuboidsfromid_urls.py
@@ -1,0 +1,24 @@
+# Copyright 2021 The Johns Hopkins University Applied Physics Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from django.conf.urls import url
+from bossobject import views
+
+app_name = 'bossobject'
+urlpatterns = [
+
+    # Url to get the bouding box for an object
+    url(r'(?P<collection>[\w_-]+)/(?P<experiment>[\w_-]+)/(?P<channel>[\w_-]+)/(?P<resolution>\d)/(?P<id>\d+)/?$',
+        views.CuboidsFromID.as_view()),
+]


### PR DESCRIPTION
**Draft PR because I haven't added tests.**

For applications in proofreading and meshing it's useful to have a way to get the cuboids that specifically belong to one ID. This functionality existed as an intermediate product of indexing and bounding boxes, so I just yanked some of that code to create a cuboid_from_id() function that returns the list of cuboid corners that contain a particular ID.

This PR adds the URL and View functions in Django. The URL is formatted in this way:
` {base_url}/v1/cuboidsfromid/:collection/:experiment:/channel/:resolution/:id`

SPDB PR: https://github.com/jhuapl-boss/spdb/pull/28