### PR TITLE
Remove Source Channel Requirement for Annotation Channels

### DIFF
--- a/django/bosscore/views/views_resource.py
+++ b/django/bosscore/views/views_resource.py
@@ -668,7 +668,10 @@ class ChannelDetail(APIView):
                 # The source and related channels are names and need to be removed from the dict before serialization
                 source_channels = channel_data.pop('sources', [])
                 related_channels = channel_data.pop('related', [])
-
+                
+                # TODO: Removed source channel requirement for annotation channels. Future update should allow source channel from
+                # different collections. 
+                
                 # Source channels have to be included for new annotation channels
                 # if 'type' in channel_data and channel_data['type'] == 'annotation' and len(source_channels) == 0:
                 #     return BossHTTPError("Annotation channels require the source channel to be set. "

--- a/django/bosscore/views/views_resource.py
+++ b/django/bosscore/views/views_resource.py
@@ -670,9 +670,9 @@ class ChannelDetail(APIView):
                 related_channels = channel_data.pop('related', [])
 
                 # Source channels have to be included for new annotation channels
-                if 'type' in channel_data and channel_data['type'] == 'annotation' and len(source_channels) == 0:
-                    return BossHTTPError("Annotation channels require the source channel to be set. "
-                                         "Specify a valid source channel in the post", ErrorCodes.INVALID_POST_ARGUMENT)
+                # if 'type' in channel_data and channel_data['type'] == 'annotation' and len(source_channels) == 0:
+                #     return BossHTTPError("Annotation channels require the source channel to be set. "
+                #                          "Specify a valid source channel in the post", ErrorCodes.INVALID_POST_ARGUMENT)
 
                 # Validate the source and related channels if they are incuded
                 channels = self.validate_source_related_channels(experiment_obj, source_channels, related_channels)


### PR DESCRIPTION
As of now, annotation channels require a source image channel from the same experiment to be created. This makes it somewhat cumbersome to create an annotation channel that is supposed to reference another collection or experiment. 

For the SABER/bossDB integration, a lot of the output products such as membranes, synapses, and neuron segmentation are usually run on public data and uploaded to a separate collection, therefore I propose we remove this requirement for now. 

In the future, a better solution would be the maintain the requirement, but let annotation channels have a source channel from another collection or experiment with an extra validation step to make sure the coordinate frames match up.  

Tested on my stack. No issues found!