### PR TITLE
Connect ingest queue to ingest lambda if not empty

### DIFF
--- a/django/bossingest/test/setup.py
+++ b/django/bossingest/test/setup.py
@@ -152,9 +152,9 @@ class SetupTests(object):
         data['ingest_job']['extent']['t'] = [0, 1]
 
         data['ingest_job']['chunk_size'] = {}
-        data['ingest_job']['chunk_size']['x'] = 512
-        data['ingest_job']['chunk_size']['y'] = 512
-        data['ingest_job']['chunk_size']['z'] = 16
+        data['ingest_job']['chunk_size']['x'] = 1024
+        data['ingest_job']['chunk_size']['y'] = 1024
+        data['ingest_job']['chunk_size']['z'] = 64
 
         data['ingest_job']['ingest_type'] = 'volumetric'
 

--- a/django/bossingest/test/test_ingest_manager.py
+++ b/django/bossingest/test/test_ingest_manager.py
@@ -77,7 +77,7 @@ class BossIngestManagerTest(APITestCase):
         assert (self.ingest_mgr.channel.name == 'my_ch_1')
 
     def test_create_ingest_job(self):
-        """Method to test creation o a ingest job from a config_data dict"""
+        """Method to test creation of a ingest job from a config_data dict"""
         self.ingest_mgr.validate_config_file(self.example_config_data)
         self.ingest_mgr.validate_properties()
         self.ingest_mgr.owner = self.user.pk
@@ -126,3 +126,16 @@ class BossIngestManagerTest(APITestCase):
         """ Test get tile bucket name"""
         tile_bucket_name = self.ingest_mgr.get_tile_bucket()
         assert(tile_bucket_name is not None)
+
+    def test_get_resource_data(self):
+        """Run the method and ensure keys set"""
+        self.ingest_mgr.validate_config_file(self.example_config_data)
+        self.ingest_mgr.validate_properties()
+        self.ingest_mgr.owner = self.user.pk
+        job = self.ingest_mgr.create_ingest_job()
+        actual = self.ingest_mgr.get_resource_data(job.id)
+        self.assertIn('boss_key', actual)
+        self.assertIn('lookup_key', actual)
+        self.assertIn('channel', actual)
+        self.assertIn('experiment', actual)
+        self.assertIn('coord_frame', actual)

--- a/django/bossingest/test/test_ingest_manager_complete.py
+++ b/django/bossingest/test/test_ingest_manager_complete.py
@@ -400,22 +400,6 @@ class BossIngestManagerCompleteTest(APITestCase):
         self.assertEqual(ErrorCodes.BAD_REQUEST, actual.error_code)
         self.assertEqual(TILE_INDEX_QUEUE_NOT_EMPTY_ERR_MSG, actual.message)
 
-    @patch('bossingest.ingest_manager.get_sqs_num_msgs', autospec=True)
-    def test_ensure_queues_empty_should_fail_if_tile_error_queue_not_empty(self, fake_get_sqs_num_msgs):
-        """Should fail if the tile error queue isn't empty."""
-        job = self.make_ingest_job(status=IngestJob.UPLOADING)
-
-        fake_get_sqs_num_msgs.side_effect = make_fake_get_sqs_num_msgs([(TILE_ERROR_QUEUE_URL, 1)])
-        self.make_fake_sqs_queues()
-
-        with self.assertRaises(BossError) as be:
-            self.ingest_mgr.ensure_queues_empty(job);
-
-        actual = be.exception
-        self.assertEqual(400, actual.status_code)
-        self.assertEqual(ErrorCodes.BAD_REQUEST, actual.error_code)
-        self.assertEqual(TILE_ERROR_QUEUE_NOT_EMPTY_ERR_MSG, actual.message)
-
     def test_start_completion_activity_exits_if_not_tile_ingest(self):
         job = self.make_ingest_job(status=IngestJob.UPLOADING)
         job.ingest_type = IngestJob.VOLUMETRIC_INGEST

--- a/django/bossingest/test/test_ingest_manager_complete.py
+++ b/django/bossingest/test/test_ingest_manager_complete.py
@@ -16,7 +16,7 @@
 This module tests the ingest completion process of IngestManager.
 """
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import ANY, call, patch, MagicMock
 from datetime import datetime, timedelta, timezone
 
 from bossingest.ingest_manager import (
@@ -27,14 +27,14 @@ from bossingest.ingest_manager import (
     TILE_INDEX_QUEUE_NOT_EMPTY_ERR_MSG,
     TILE_ERROR_QUEUE_NOT_EMPTY_ERR_MSG,
     ALREADY_COMPLETING_ERR_MSG,
-    WAIT_FOR_QUEUES_SECS
+    WAIT_FOR_QUEUES_SECS,
+    INGEST_LAMBDA,
 )
 from bossingest.models import IngestJob
 from bossingest.test.setup import SetupTests
 from bosscore.test.setup_db import SetupTestDB
 from bosscore.error import BossError, ErrorCodes
 from django.contrib.auth.models import User
-import django.utils.timezone
 from ndingest.ndqueue.uploadqueue import UploadQueue
 from ndingest.ndqueue.ingestqueue import IngestQueue
 from ndingest.ndqueue.tileindexqueue import TileIndexQueue
@@ -357,6 +357,7 @@ class BossIngestManagerCompleteTest(APITestCase):
 
         fake_get_sqs_num_msgs.side_effect = make_fake_get_sqs_num_msgs([(INGEST_QUEUE_URL, 1)])
         self.make_fake_sqs_queues()
+        self.patch_ingest_mgr('lambda_connect_sqs')
 
         with self.assertRaises(BossError) as be:
             self.ingest_mgr.ensure_queues_empty(job);
@@ -365,6 +366,19 @@ class BossIngestManagerCompleteTest(APITestCase):
         self.assertEqual(400, actual.status_code)
         self.assertEqual(ErrorCodes.BAD_REQUEST, actual.error_code)
         self.assertEqual(INGEST_QUEUE_NOT_EMPTY_ERR_MSG, actual.message)
+
+    @patch('bossingest.ingest_manager.get_sqs_num_msgs', autospec=True)
+    def test_ensure_queues_empty_should_attach_ingest_lambda_if_ingest_queue_not_empty(self, fake_get_sqs_num_msgs):
+        """Should fail if the ingest queue isn't empty."""
+        job = self.make_ingest_job(status=IngestJob.UPLOADING)
+
+        fake_get_sqs_num_msgs.side_effect = make_fake_get_sqs_num_msgs([(INGEST_QUEUE_URL, 1)])
+        self.make_fake_sqs_queues()
+        fake_lambda_connect = self.patch_ingest_mgr('lambda_connect_sqs')
+
+        with self.assertRaises(BossError):
+            self.ingest_mgr.ensure_queues_empty(job);
+        self.assertEquals(fake_lambda_connect.call_args_list, [call(ANY, INGEST_LAMBDA)])
 
     @patch('bossingest.ingest_manager.get_sqs_num_msgs', autospec=True)
     def test_ensure_queues_empty_should_fail_if_tile_index_queue_not_empty(self, fake_get_sqs_num_msgs):

--- a/django/bossingest/test/test_ingest_manager_complete.py
+++ b/django/bossingest/test/test_ingest_manager_complete.py
@@ -128,6 +128,7 @@ class BossIngestManagerCompleteTest(APITestCase):
         upload_q = MagicMock(spec=UploadQueue)
         upload_q.url = UPLOAD_QUEUE_URL
         upload_q.region_name = self.region
+        upload_q.queue = MagicMock()
 
         get_upload_q = self.patch_ingest_mgr('get_ingest_job_upload_queue')
         get_upload_q.return_value = upload_q
@@ -135,6 +136,7 @@ class BossIngestManagerCompleteTest(APITestCase):
         ingest_q = MagicMock(spec=IngestQueue)
         ingest_q.url = INGEST_QUEUE_URL
         ingest_q.region_name = self.region
+        ingest_q.queue = MagicMock()
 
         get_ingest_q = self.patch_ingest_mgr('get_ingest_job_ingest_queue')
         get_ingest_q.return_value = ingest_q
@@ -142,6 +144,7 @@ class BossIngestManagerCompleteTest(APITestCase):
         tile_index_q = MagicMock(spec=TileIndexQueue)
         tile_index_q.url = TILE_INDEX_QUEUE_URL
         tile_index_q.region_name = self.region
+        tile_index_q.queue = MagicMock()
 
         get_tile_index_q = self.patch_ingest_mgr('get_ingest_job_tile_index_queue')
         get_tile_index_q.return_value = tile_index_q
@@ -149,6 +152,7 @@ class BossIngestManagerCompleteTest(APITestCase):
         tile_error_q = MagicMock(spec=TileErrorQueue)
         tile_error_q.url = TILE_ERROR_QUEUE_URL
         tile_error_q.region_name = self.region
+        tile_error_q.queue = MagicMock()
 
         get_tile_error_q = self.patch_ingest_mgr('get_ingest_job_tile_error_queue')
         get_tile_error_q.return_value = tile_error_q

--- a/django/bossingest/test/test_ingest_views.py
+++ b/django/bossingest/test/test_ingest_views.py
@@ -20,6 +20,7 @@ from bosscore.constants import ADMIN_USER
 from bosscore.error import BossError, ErrorCodes
 from bossingest.ingest_manager import IngestManager, INGEST_QUEUE_NOT_EMPTY_ERR_MSG
 from bossingest.models import IngestJob
+from bossutils.ingestcreds import IngestCredentials
 
 
 version = settings.BOSS_VERSION

--- a/django/bossingest/test/test_ingest_views.py
+++ b/django/bossingest/test/test_ingest_views.py
@@ -152,8 +152,8 @@ class TestBossIngestView(APITestCase):
         resp = self.client.post(url, format='json')
         self.assertEqual(400, resp.status_code)
         actual = resp.json()
-        self.assertEqual(ErrorCodes.BAD_REQUEST, actual['code'])
-        self.assertEqual(400, actual['status'])
+        self.assertIn('wait_secs', actual)
+        self.assertIn('info', actual)
 
     def test_complete_should_fail_if_wait_on_queues_still_waiting(self, ingest_mgr_creator):
         """Should get a failure response along with how much longer to wait."""

--- a/django/bossingest/views.py
+++ b/django/bossingest/views.py
@@ -420,7 +420,7 @@ class IngestJobCompleteView(IngestServiceView):
             except BossError as be:
                 if (be.message == INGEST_QUEUE_NOT_EMPTY_ERR_MSG or
                         be.message == TILE_INDEX_QUEUE_NOT_EMPTY_ERR_MSG or
-                        be.message == TILE_INDEX_QUEUE_NOT_EMPTY_ERR_MSG):
+                        be.message == INGEST_QUEUE_NOT_EMPTY_ERR_MSG):
                     return Response(
                         data={ 'wait_secs': WAIT_FOR_QUEUES_SECS, 'info': 'Internal queues not empty yet' },
                         status=status.HTTP_400_BAD_REQUEST)

--- a/django/bossingest/views.py
+++ b/django/bossingest/views.py
@@ -392,8 +392,10 @@ class IngestJobCompleteView(IngestServiceView):
                     return Response(data=data, status=status.HTTP_202_ACCEPTED)
                 except BossError as be:
                     if (be.message == INGEST_QUEUE_NOT_EMPTY_ERR_MSG or
-                            be.message == TILE_INDEX_QUEUE_NOT_EMPTY_ERR_MSG or
-                            be.message == INGEST_QUEUE_NOT_EMPTY_ERR_MSG):
+                            be.message == TILE_INDEX_QUEUE_NOT_EMPTY_ERR_MSG):
+                        # If there are messages in the tile error queue, this
+                        # will have to be handled manually.  Non-empty ingest
+                        # or tile index queues should resolve on their own.
                         return Response(
                             data={ 'wait_secs': WAIT_FOR_QUEUES_SECS, 'info': 'Internal queues not empty yet' },
                             status=status.HTTP_400_BAD_REQUEST)

--- a/django/bossingest/views.py
+++ b/django/bossingest/views.py
@@ -171,6 +171,12 @@ class IngestJobView(IngestServiceView):
             # Set resource
             data['resource'] = ingest_mgmr.get_resource_data(ingest_job_id)
 
+            # ingest_lambda is no longer required by the backend.  The backend
+            # gets the name of the ingest lambda from boss-manage/lib/names.py.
+            # Keep providing it in case an older ingest client used (which
+            # still expects it).
+            data['ingest_lambda'] = 'deprecated'
+
             return Response(data, status=status.HTTP_200_OK)
         except BossError as err:
                 return err.to_http()

--- a/django/mgmt/static/js/ingest.js
+++ b/django/mgmt/static/js/ingest.js
@@ -1,36 +1,47 @@
 
+const STATUS_NAME = 0;
+const ENABLE_COMPLETE_BTN = 1;
+const ENABLE_CANCEL_BTN = 2;
+
+const statusMap = {
+  // Tuple values are name, can-complete, can-cancel.
+  0: ['Preparing', false, true],
+  1: ['Uploading', false, true],
+  2: ['Complete', false, false],
+  3: ['Deleted', false, false],
+  4: ['Failed', false, false],
+  5: ['Completing', false, false],
+  6: ['Wait on queues', true, false],
+};
+
 function get_status_str(val){
-    var status = "Preparing";
-    if (val == 1) {
-        status = "Uploading";
-    } else if (val == 2) {
-        status = "Complete";
-    } else if (val == 3) {
-        status = "Deleted";
-    } else if (val == 4) {
-        status = "Failed";
+    let status = "Unknown";
+    if (statusMap.hasOwnProperty(val)) {
+      status = statusMap[val][STATUS_NAME];
+    } else {
+        console.error(`Got unknown ingest status ${val}`);
     }
     return status
 }
 
 function set_button_modes(val) {
+    if (statusMap.hasOwnProperty(val)) {
+        const completable = statusMap[val][ENABLE_COMPLETE_BTN];
+        const cancellable = statusMap[val][ENABLE_CANCEL_BTN];
 
-    if (val == 0) {
-        // Preparing
-        $("#complete-btn").addClass('disabled');
-        $("#cancel-btn").removeClass('disabled');
-    } else if (val == 1) {
-        // Uploading
-        $("#complete-btn").addClass('disabled');
-        $("#cancel-btn").removeClass('disabled');
-    } else if (val == 2) {
-        // Complete
-        $("#complete-btn").addClass('disabled');
-        $("#cancel-btn").addClass('disabled');
+        if (completable) {
+            $("#complete-btn").removeClass('disabled');
+        } else {
+            $("#complete-btn").addClass('disabled');
+        }
+
+        if (cancellable) {
+            $("#cancel-btn").removeClass('disabled');
+        } else {
+            $("#cancel-btn").addClass('disabled');
+        }
     } else {
-        // Canceled or Failed
-        $("#complete-btn").addClass('disabled');
-        $("#cancel-btn").addClass('disabled');
+        console.error(`Got unknown ingest status ${val}`);
     }
 }
 

--- a/django/sso/tests/test_user_roles.py
+++ b/django/sso/tests/test_user_roles.py
@@ -12,6 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Note that these tests all pass when run in isolation when run locally, but
+there are several failures when all tests run together:
+
+FAIL: test_delete_role (sso.tests.test_user_roles.TestBossUserRole)
+FAIL: test_failed_delete_role (sso.tests.test_user_roles.TestBossUserRole)
+FAIL: test_failed_get_role (sso.tests.test_user_roles.TestBossUserRole)
+FAIL: test_failed_post_role (sso.tests.test_user_roles.TestBossUserRole)
+FAIL: test_get_role_no_role (sso.tests.test_user_roles.TestBossUserRole)
+FAIL: test_get_role_with_role (sso.tests.test_user_roles.TestBossUserRole)
+FAIL: test_get_role_with_role1 (sso.tests.test_user_roles.TestBossUserRole)
+FAIL: test_post_role (sso.tests.test_user_roles.TestBossUserRole)
+"""
+
 from unittest import mock
 import json
 

--- a/django/sso/tests/test_users.py
+++ b/django/sso/tests/test_users.py
@@ -12,6 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Note that these tests all pass when run in isolation when run locally, but
+there are several failures when all tests run together:
+
+FAIL: test_delete_user (sso.tests.test_users.TestBossUser)
+FAIL: test_delete_user_bossadmin (sso.tests.test_users.TestBossUser)
+FAIL: test_failed_delete_user (sso.tests.test_users.TestBossUser)
+FAIL: test_failed_post_user (sso.tests.test_users.TestBossUser)
+FAIL: test_failed_post_user_rollback (sso.tests.test_users.TestBossUser)
+FAIL: test_post_user (sso.tests.test_users.TestBossUser)
+"""
+
 from unittest import mock
 
 # This must be imported before the views class so check_role() can be properly


### PR DESCRIPTION
Updates to the Boss endpoint to make ingest more robust:

The ingest queue is connected as an event source to the ingest lambda if it's non-empty when a complete request is received.

During ingest completion, any chunks with all of their tiles present are placed back in the ingest queue.

Updated ingest web page to recognize new ingest status types (WAIT_ON_QUEUES, COMPLETING).

Noted 14 tests that fail when run with the entire test suite but pass when run in isolation (users and user roles). These tests were not broken by this PR, but have been broken for some time. :(

### Related PRs:
https://github.com/jhuapl-boss/boss-tools/pull/50
https://github.com/jhuapl-boss/ingest-client/pull/54