### PR TITLE
cloud-volume support for bossspatialdb

### DIFF
--- a/django/bosscore/test/setup_db.py
+++ b/django/bosscore/test/setup_db.py
@@ -164,6 +164,17 @@ class SetupTestDB:
         # bbchan1 is a channel for bounding box tests.
         self.add_channel('col1', 'exp1', 'bbchan1', 0, 0, 'uint64', 'annotation', ['channel1'])
 
+    def insert_cloudvolume_test_data(self):
+        """
+        Test data for cloudvolume integration.
+        """
+        self.add_collection('col1', 'Description for collection1')
+        self.add_coordinate_frame('cf1', 'Description for cf1', 0, 100000, 0, 100000, 0, 100000, 4, 4, 4)
+        self.add_experiment('col1', 'exp1', 'cf1', 10, 500, 1)
+        self.add_channel('col1', 'exp1', 'chan1', 0, 0, 'uint8', 'image', storage_type='cloudvol', bucket='bossdb-test-data')
+        self.add_channel('col1', 'exp1', 'chan2', 0, 0, 'uint16', 'image', storage_type='cloudvol', bucket='bossdb-test-data')
+        self.add_channel('col1', 'exp1', 'anno1', 0, 0, 'uint64', 'annotation', ['channel1'], storage_type='cloudvol', bucket='bossdb-test-data')
+
     def insert_ingest_test_data(self):
 
         self.add_collection('my_col_1', 'Description for collection1')
@@ -317,7 +328,8 @@ class SetupTestDB:
 
     def add_channel(self, collection_name, experiment_name, channel_name,
                     default_time_sample, base_resolution, datatype, 
-                    channel_type=None, source_channels=[], public=False):
+                    channel_type=None, source_channels=[], public=False, storage_type='spdb', 
+                    bucket=None, cv_path=None):
         """
 
         Args:
@@ -330,6 +342,9 @@ class SetupTestDB:
             channel_type (str):  Channel Type (image or annotation)
             source_channels (list[str]): Source channel(s) for an annotation channel
             public (bool): Is channel public?  Defaults to False.
+            storage_type (str): storage backend. default to spdb
+            bucket (str | null): source bucket. if null defaults to cuboids bucket
+            cv_path (str | null): cloudpath for cloudvolume data if backend is cloudvol. 
 
         Returns:
             Channel
@@ -348,7 +363,7 @@ class SetupTestDB:
         channel = Channel.objects.create(name=channel_name, experiment=exp,
                                          default_time_sample=default_time_sample, base_resolution=base_resolution,
                                          type=channel_type, datatype=datatype, creator=self.user,
-                                         public=public)
+                                         public=public, storage_type=storage_type, bucket=bucket, cv_path=cv_path)
 
         src_chan_objs, rel_chan_objs = ChannelDetail.validate_source_related_channels(
                 exp, source_channels, related_channels)

--- a/django/bossspatialdb/test/cutout_view_cloudvolume.py
+++ b/django/bossspatialdb/test/cutout_view_cloudvolume.py
@@ -1,0 +1,335 @@
+# Copyright 2021 The Johns Hopkins University Applied Physics Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from django.conf import settings
+import blosc
+
+from rest_framework.test import APITestCase, APIRequestFactory
+from rest_framework.test import force_authenticate
+from rest_framework import status
+
+from bossspatialdb.views import Cutout
+
+from bosscore.test.setup_db import SetupTestDB
+from bosscore.error import BossError
+
+import numpy as np
+import zlib
+import io
+import time
+from PIL import Image
+from cloudvolume import CloudVolume
+
+
+# S3 Bucket for CloudVolume Testing.
+TEST_BUCKET = "bossdb-test-data"
+
+# bossDB API Version
+version = settings.BOSS_VERSION
+
+class CutoutInterfaceViewCloudVolumeMixin(object):
+    def test_channel_uint8_cuboid_aligned(self):
+        "uint8 - cuboid aligned - no offset"
+        # Generate random data
+        test_mat = np.random.randint(1, 254, (16, 128, 128))
+        test_mat = test_mat.astype(np.uint8)
+
+        # Upload Data to Cloudvolume
+        self.vol_uint8[0:128, 0:128, 0:16] = test_mat.T
+
+        # Create Request to get data you posted
+        factory = APIRequestFactory()
+        request = factory.get('/' + version + '/cutout/col1/exp1/chan1/0/0:128/0:128/0:16/',
+                              accepts='application/blosc')
+
+        # log in user
+        force_authenticate(request, user=self.user)
+
+        # Make request
+        response = Cutout.as_view()(request, collection='col1', experiment='exp1', channel='chan1',
+                                    resolution='0', x_range='0:128', y_range='0:128', z_range='0:16', t_range=None).render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Decompress
+        raw_data = blosc.decompress(response.content)
+        data_mat = np.fromstring(raw_data, dtype=np.uint8)
+        data_mat = np.reshape(data_mat, (16, 128, 128), order='C')
+
+        # Test for data equality (what you put in is what you got back!)
+        np.testing.assert_array_equal(data_mat, test_mat)
+
+    def test_channel_uint8_cuboid_aligned_offset(self):
+        "uint8 - cuboid aligned - offset present"
+        # Generate random data
+        test_mat = np.random.randint(1, 254, (16, 512, 512))
+        test_mat = test_mat.astype(np.uint8)
+
+        # Upload Data to Cloudvolume
+        self.vol_uint8[0:512, 0:512, 16:32] = test_mat.T
+
+        # Create Request to get data you posted
+        factory = APIRequestFactory()
+        request = factory.get('/' + version + '/cutout/col1/exp1/chan1/0/128:256/256:384/16:32/',
+                              accepts='application/blosc')
+
+        # log in user
+        force_authenticate(request, user=self.user)
+
+        # Make request
+        response = Cutout.as_view()(request, collection='col1', experiment='exp1', channel='chan1',
+                                    resolution='0', x_range='128:256', y_range='256:384', z_range='16:32', t_range=None).render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Decompress
+        raw_data = blosc.decompress(response.content)
+        data_mat = np.fromstring(raw_data, dtype=np.uint8)
+        data_mat = np.reshape(data_mat, (16, 128, 128), order='C')
+
+        # Test for data equality (what you put in is what you got back!)
+        offset_mat = test_mat[:, 256:384, 128:256]
+        np.testing.assert_array_equal(data_mat, offset_mat)
+
+    def test_channel_uint8_cuboid_unaligned_offset(self):
+        "uint8 - cuboid unaligned - offset present"
+        # Generate random data
+        test_mat = np.random.randint(1, 254, (32, 512, 1024))
+        test_mat = test_mat.astype(np.uint8)
+
+        # Upload Data to Cloudvolume
+        self.vol_uint8[0:1024, 0:512, 0:32] = test_mat.T
+
+        # Create Request to get data you posted
+        factory = APIRequestFactory()
+        request = factory.get('/' + version + '/cutout/col1/exp1/chan1/0/140:692/256:384/7:31/',
+                              accepts='application/blosc')
+
+        # log in user
+        force_authenticate(request, user=self.user)
+
+        # Make request
+        response = Cutout.as_view()(request, collection='col1', experiment='exp1', channel='chan1',
+                                    resolution='0', x_range='140:692', y_range='256:384', z_range='7:31', t_range=None).render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Decompress
+        raw_data = blosc.decompress(response.content)
+        data_mat = np.fromstring(raw_data, dtype=np.uint8)
+        data_mat = np.reshape(data_mat, (24, 128, 552), order='C')
+
+        # Test for data equality (what you put in is what you got back!)
+        offset_mat = test_mat[7:31, 256:384, 140:692]
+        np.testing.assert_array_equal(data_mat, offset_mat)
+    
+    def test_channel_uint16_cuboid_aligned(self):
+        "uint16 - cuboid aligned - no offset"
+        # Generate random data
+        test_mat = np.random.randint(1, 2**16-1, (16, 128, 128))
+        test_mat = test_mat.astype(np.uint16)
+
+        # Upload Data to Cloudvolume
+        self.vol_uint16[0:128, 0:128, 0:16] = test_mat.T
+
+        # Create Request to get data you posted
+        factory = APIRequestFactory()
+        request = factory.get('/' + version + '/cutout/col1/exp1/chan2/0/0:128/0:128/0:16/',
+                              accepts='application/blosc')
+
+        # log in user
+        force_authenticate(request, user=self.user)
+
+        # Make request
+        response = Cutout.as_view()(request, collection='col1', experiment='exp1', channel='chan2',
+                                    resolution='0', x_range='0:128', y_range='0:128', z_range='0:16', t_range=None).render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Decompress
+        raw_data = blosc.decompress(response.content)
+        data_mat = np.fromstring(raw_data, dtype=np.uint16)
+        data_mat = np.reshape(data_mat, (16, 128, 128), order='C')
+
+        # Test for data equality (what you put in is what you got back!)
+        np.testing.assert_array_equal(data_mat, test_mat)
+
+    def test_channel_uint16_cuboid_aligned_offset(self):
+        "uint16 - cuboid aligned - offset present"
+        # Generate random data
+        test_mat = np.random.randint(1, 2**16-1, (16, 512, 512))
+        test_mat = test_mat.astype(np.uint16)
+
+        # Upload Data to Cloudvolume
+        self.vol_uint16[0:512, 0:512, 16:32] = test_mat.T
+
+        # Create Request to get data you posted
+        factory = APIRequestFactory()
+        request = factory.get('/' + version + '/cutout/col1/exp1/chan2/0/128:256/256:384/16:32/',
+                              accepts='application/blosc')
+
+        # log in user
+        force_authenticate(request, user=self.user)
+
+        # Make request
+        response = Cutout.as_view()(request, collection='col1', experiment='exp1', channel='chan2',
+                                    resolution='0', x_range='128:256', y_range='256:384', z_range='16:32', t_range=None).render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Decompress
+        raw_data = blosc.decompress(response.content)
+        data_mat = np.fromstring(raw_data, dtype=np.uint16)
+        data_mat = np.reshape(data_mat, (16, 128, 128), order='C')
+
+        # Test for data equality (what you put in is what you got back!)
+        offset_mat = test_mat[:, 256:384, 128:256]
+        np.testing.assert_array_equal(data_mat, offset_mat)
+
+    def test_channel_uint16_cuboid_unaligned_offset(self):
+        "uint16 - cuboid unaligned - offset present"
+        # Generate random data
+        test_mat = np.random.randint(1, 2**16-1, (32, 512, 1024))
+        test_mat = test_mat.astype(np.uint16)
+
+        # Upload Data to Cloudvolume
+        self.vol_uint16[0:1024, 0:512, 0:32] = test_mat.T
+
+        # Create Request to get data you posted
+        factory = APIRequestFactory()
+        request = factory.get('/' + version + '/cutout/col1/exp1/chan2/0/140:692/256:384/7:31/',
+                              accepts='application/blosc')
+
+        # log in user
+        force_authenticate(request, user=self.user)
+
+        # Make request
+        response = Cutout.as_view()(request, collection='col1', experiment='exp1', channel='chan2',
+                                    resolution='0', x_range='140:692', y_range='256:384', z_range='7:31', t_range=None).render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Decompress
+        raw_data = blosc.decompress(response.content)
+        data_mat = np.fromstring(raw_data, dtype=np.uint16)
+        data_mat = np.reshape(data_mat, (24, 128, 552), order='C')
+
+        # Test for data equality (what you put in is what you got back!)
+        offset_mat = test_mat[7:31, 256:384, 140:692]
+        np.testing.assert_array_equal(data_mat, offset_mat)
+
+    def test_channel_uint64_cuboid_aligned(self):
+        "uint64 - cuboid aligned - no offset"
+        # Generate random data
+        test_mat = np.random.randint(1, 2**64-1, (16, 128, 128))
+        test_mat = test_mat.astype(np.uint64)
+
+        # Upload Data to Cloudvolume
+        self.vol_uint64[0:128, 0:128, 0:16] = test_mat.T
+
+        # Create Request to get data you posted
+        factory = APIRequestFactory()
+        request = factory.get('/' + version + '/cutout/col1/exp1/anno1/0/0:128/0:128/0:16/',
+                              accepts='application/blosc')
+
+        # log in user
+        force_authenticate(request, user=self.user)
+
+        # Make request
+        response = Cutout.as_view()(request, collection='col1', experiment='exp1', channel='anno1',
+                                    resolution='0', x_range='0:128', y_range='0:128', z_range='0:16', t_range=None).render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Decompress
+        raw_data = blosc.decompress(response.content)
+        data_mat = np.fromstring(raw_data, dtype=np.uint64)
+        data_mat = np.reshape(data_mat, (16, 128, 128), order='C')
+
+        # Test for data equality (what you put in is what you got back!)
+        np.testing.assert_array_equal(data_mat, test_mat)
+
+    def test_channel_uint64_cuboid_aligned_offset(self):
+        "uint64 - cuboid aligned - offset present"
+        # Generate random data
+        test_mat = np.random.randint(1, 2**64-1, (16, 512, 512))
+        test_mat = test_mat.astype(np.uint64)
+
+        # Upload Data to Cloudvolume
+        self.vol_uint64[0:512, 0:512, 16:32] = test_mat.T
+
+        # Create Request to get data you posted
+        factory = APIRequestFactory()
+        request = factory.get('/' + version + '/cutout/col1/exp1/anno1/0/128:256/256:384/16:32/',
+                              accepts='application/blosc')
+
+        # log in user
+        force_authenticate(request, user=self.user)
+
+        # Make request
+        response = Cutout.as_view()(request, collection='col1', experiment='exp1', channel='anno1',
+                                    resolution='0', x_range='128:256', y_range='256:384', z_range='16:32', t_range=None).render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Decompress
+        raw_data = blosc.decompress(response.content)
+        data_mat = np.fromstring(raw_data, dtype=np.uint64)
+        data_mat = np.reshape(data_mat, (16, 128, 128), order='C')
+
+        # Test for data equality (what you put in is what you got back!)
+        offset_mat = test_mat[:, 256:384, 128:256]
+        np.testing.assert_array_equal(data_mat, offset_mat)
+
+    def test_channel_uint64_cuboid_unaligned_offset(self):
+        "uint64 - cuboid unaligned - offset present"
+        # Generate random data
+        test_mat = np.random.randint(1, 2**64-1, (32, 512, 1024))
+        test_mat = test_mat.astype(np.uint64)
+
+        # Upload Data to Cloudvolume
+        self.vol_uint64[0:1024, 0:512, 0:32] = test_mat.T
+
+        # Create Request to get data you posted
+        factory = APIRequestFactory()
+        request = factory.get('/' + version + '/cutout/col1/exp1/anno1/0/140:692/256:384/7:31/',
+                              accepts='application/blosc')
+
+        # log in user
+        force_authenticate(request, user=self.user)
+
+        # Make request
+        response = Cutout.as_view()(request, collection='col1', experiment='exp1', channel='anno1',
+                                    resolution='0', x_range='140:692', y_range='256:384', z_range='7:31', t_range=None).render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Decompress
+        raw_data = blosc.decompress(response.content)
+        data_mat = np.fromstring(raw_data, dtype=np.uint64)
+        data_mat = np.reshape(data_mat, (24, 128, 552), order='C')
+
+        # Test for data equality (what you put in is what you got back!)
+        offset_mat = test_mat[7:31, 256:384, 140:692]
+        np.testing.assert_array_equal(data_mat, offset_mat)
+
+class TestCutoutCloudVolumeInterfaceView(CutoutInterfaceViewCloudVolumeMixin, APITestCase):
+    
+    @classmethod
+    def setUpClass(cls):
+        """ Set everything up for testing """
+        # Create a user
+        cls.dbsetup = SetupTestDB()
+        cls.user = cls.dbsetup.create_user('testuser')
+
+        # Populate DB
+        cls.dbsetup.insert_cloudvolume_test_data()
+
+        # Set up external cloudvolume instance
+        # TODO: Fails if cloudvolume not already set up. Make method that creates new cloudvolume.
+        cls.vol_uint8 = CloudVolume(f"s3://{TEST_BUCKET}/col1/exp1/chan1")
+        cls.vol_uint16 = CloudVolume(f"s3://{TEST_BUCKET}/col1/exp1/chan2")
+        cls.vol_uint64 = CloudVolume(f"s3://{TEST_BUCKET}/col1/exp1/anno1")
+

--- a/django/bossspatialdb/views.py
+++ b/django/bossspatialdb/views.py
@@ -38,6 +38,9 @@ from bosscore.models import ThrottleMetric
 from spdb.spatialdb.spatialdb import SpatialDB, CUBOIDSIZE
 from spdb.spatialdb.rediskvio import RedisKVIO
 from spdb import project
+
+from cvdb.cloudvolumedb import CloudVolumeDB
+
 import bossutils
 from bossutils.logger import bossLogger
 from bossspatialdb.downsample import delete_queued_job, start
@@ -174,10 +177,14 @@ class Cutout(APIView):
 
 
 
-        # Get interface to SPDB cache
-        cache = SpatialDB(settings.KVIO_SETTINGS,
-                          settings.STATEIO_CONFIG,
-                          settings.OBJECTIO_CONFIG)
+        # Get interface to SPDB or CVDB cache
+
+        if resource.get_channel().is_cloudvolume():
+            cache = CloudVolumeDB()
+        else:
+            cache = SpatialDB(settings.KVIO_SETTINGS,
+                            settings.STATEIO_CONFIG,
+                            settings.OBJECTIO_CONFIG)
 
         # Get the params to pull data out of the cache
         corner = (req.get_x_start(), req.get_y_start(), req.get_z_start())

--- a/django/mgmt/forms.py
+++ b/django/mgmt/forms.py
@@ -207,11 +207,11 @@ class ChannelForm(UpdateForm):
         """
         self.UPDATE_FIELDS = self.BASE_UPDATE_FIELDS
 
-        is_admin = self.form.get('is_admin', False)
+        is_admin = self.fields.get('is_admin', False)
         if is_admin:
             self.UPDATE_FIELDS += ['storage_type', 'bucket', 'cv_path']
 
-        super.is_update()
+        return super().is_update()
 
 
 def PermField():


### PR DESCRIPTION
This PR allows for cloud-volume data to be processed correctly by the API. 

- Adds CVDB library to BossSpatialDB, specifically the cutout GET view.  
- Adds django resource and cutout view unit tests.
- Fixes typo in mgmt/forms.py.

Integration tests still in progress.