### PR TITLE
Update auth logic for listing public resources.

### DIFF
--- a/django/bosscore/test/setup_db.py
+++ b/django/bosscore/test/setup_db.py
@@ -42,8 +42,18 @@ TEST_DATA_EXPERIMENTS = [EXP1, EXP22, EXP_BASE_RES]
 CHAN_BASE_RES = 'chan-with-base-res'
 
 class SetupTestDB:
-    def __init__(self):
-        self.super_user = None
+    def __init__(self, super_user=None):
+        """
+        Constructor.
+
+        An existing super user may be supplied when creating an another
+        instance of this class for additional test DB configuration.
+
+        Args:
+            super_user (Optional[User]): Provide an existing super user.
+        """
+        self.super_user = super_user
+        self.user = super_user
 
     def create_user(self, username=None):
         # If you have yet to create the superuser, you need to do that first for permissions to work OK

--- a/django/bosscore/test/test_resource_views.py
+++ b/django/bosscore/test/test_resource_views.py
@@ -767,7 +767,6 @@ class ResourceViewsChannelTests(APITestCase):
         response = self.client.post(url, data=data)
         self.assertEqual(response.status_code, 403)
 
-
     def test_post_channel_set_bucket_as_admin(self):
         """
         Only admins should be able to set the bucket name.
@@ -1284,7 +1283,7 @@ class ResourceViewsChannelTests(APITestCase):
         """
         url = '/' + version + '/collection/col1/experiment/exp1/channel/'
 
-        # Get an existing collection
+        # Get an existing channel
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['channels'][0], 'channel1')


### PR DESCRIPTION
Public resources needed changes to the ListAPIViews used for listing
collections, experiments, channels available to the user.

Previous logic only lists resources that the user has explicit read
permission for.