### PR TITLE
Allow cv path to be empty for SPDB channels on web form

### DIFF
--- a/django/bosscore/models.py
+++ b/django/bosscore/models.py
@@ -317,7 +317,7 @@ class Channel(models.Model):
 
     # Optional CloudVolume path.  If storage_type == StorageType.CLOUD_VOLUME,
     # then instantiate CloudVolume with: f"s3://{bucket}{cv_path}"
-    cv_path = models.CharField(null=True, max_length=2000)
+    cv_path = models.CharField(null=True, blank=True, max_length=2000)
 
     class Meta:
         db_table = u"channel"

--- a/django/mgmt/forms.py
+++ b/django/mgmt/forms.py
@@ -210,7 +210,7 @@ class ChannelForm(UpdateForm):
         Augment the set of fields that are updatable if user had admin privileges.
         """
         self.UPDATE_FIELDS = self.BASE_UPDATE_FIELDS.copy()
-        is_admin = self.fields.get('is_admin', False)
+        is_admin = self.data.get('is_admin', False)
         if is_admin:
             self.UPDATE_FIELDS += ['storage_type', 'bucket', 'cv_path']
 

--- a/django/mgmt/forms.py
+++ b/django/mgmt/forms.py
@@ -186,7 +186,10 @@ class ChannelForm(UpdateForm):
     bucket = forms.CharField(required=False, empty_value=f'cuboids{domain}',
                              help_text=f'(default is cuboids{domain})',
                              label='Bucket Name')
-    cv_path = forms.CharField(required=False, help_text='CloudVolume path', label='CloudVolume Path')
+    
+    cv_path = forms.CharField(required=False, 
+                              help_text='Public S3 URI to Cloudvolume Dataset', 
+                              label='CloudVolume Path')
 
     type = forms.ChoiceField(choices=[(c,c) for c in ['', 'image', 'annotation']],
                              help_text="image = source image dataset<br>annotation = label dataset")

--- a/django/mgmt/views.py
+++ b/django/mgmt/views.py
@@ -740,6 +740,13 @@ class Channel(LoginRequiredMixin, View):
             return self.get(request, collection_name, experiment_name, channel_name, perms_form=form)
         elif action == 'update':
             form = ChannelForm(request.POST)
+
+            # DEV NOTE: Some fields only update-able if request originates from admin
+            is_admin = BossPermissionManager.is_in_group(request.user, ADMIN_GRP)
+            data = form.data.copy()
+            data['is_admin'] = is_admin
+            form.data = data
+
             if form.is_valid():
                 data = form.cleaned_update_data
 


### PR DESCRIPTION
Fixes https://jira.xrcs.jhuapl.edu/browse/MICRONS-1843

In the channel model, the charfield for cv_path needs `blank=True` for validation to pass. Also updated the help text in forms.py to be more descriptive. 

EDIT: Also fixes issue where admins couldn't update some fields in the channel form after creation. 