### PR TITLE
Fix error creating channel via form as non-admin.

### DIFF
--- a/django/bosscore/models.py
+++ b/django/bosscore/models.py
@@ -292,7 +292,7 @@ class Channel(models.Model):
         (DownsampleStatus.FAILED, 'Failed'),
     )
     downsample_status = models.CharField(choices=DOWNSAMPLE_STATUS_CHOICES, default=DownsampleStatus.NOT_DOWNSAMPLED, max_length=100)
-    downsample_arn = models.CharField(max_length=4096, blank=True, null=True)
+    downsample_arn = models.CharField(max_length=4096, null=True)
 
     # Is this a public channel?
     public = models.BooleanField(null=False, default=False)

--- a/django/bosscore/test/test_resource_views.py
+++ b/django/bosscore/test/test_resource_views.py
@@ -19,7 +19,6 @@ from bosscore.models import Channel
 
 version = settings.BOSS_VERSION
 
-
 class ResourceViewsCollectionTests(APITestCase):
     """
     Class to test the resource service
@@ -773,9 +772,11 @@ class ResourceViewsChannelTests(APITestCase):
         """
         self.client.force_login(self.super_user)
         url = '/' + version + '/collection/col1/experiment/exp1/channel/channel10/'
-        data = {'description': 'This is a new channel', 'datatype': 'uint8', 'type': 'image', 'bucket': 'my.bucket.boss'}
+        bucket_name = 'my.bucket.boss'
+        data = {'description': 'This is a new channel', 'datatype': 'uint8', 'type': 'image', 'bucket': bucket_name}
         response = self.client.post(url, data=data)
         self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data['bucket'], bucket_name)
 
     def test_post_channel_spdb_with_cv_path(self):
         """

--- a/django/bosscore/views/views_resource.py
+++ b/django/bosscore/views/views_resource.py
@@ -34,7 +34,15 @@ from bosscore.serializers import CollectionSerializer, ExperimentSerializer, Cha
 
 from bosscore.models import Collection, Experiment, Channel, CoordinateFrame 
 from bosscore.constants import ADMIN_GRP
+from bossutils.configuration import BossConfig
+from bossutils.logger import bossLogger
 
+boss_config = BossConfig()
+try:
+    DEFAULT_CUBOID_BUCKET_NAME = 'cuboids.' + boss_config['system']['fqdn'].split('.', 1)[1]
+except Exception as ex:
+    DEFAULT_CUBOID_BUCKET_NAME = ''
+    bossLogger().error(f'Failed getting system.fqdn from boss.config: {ex}')
 
 class CollectionDetail(APIView):
 
@@ -648,10 +656,10 @@ class ChannelDetail(APIView):
 
         try:
             is_admin = BossPermissionManager.is_in_group(request.user, ADMIN_GRP)
-            if 'bucket' in channel_data and channel_data['bucket'] != '' and not is_admin:
+            if 'bucket' in channel_data and channel_data['bucket'] and not is_admin:
                 return BossHTTPError('Only admins can set bucket name', ErrorCodes.MISSING_PERMISSION)
 
-            if 'cv_path' in channel_data and channel_data['cv_path'] != '' and not is_admin:
+            if 'cv_path' in channel_data and channel_data['cv_path'] and not is_admin:
                 return BossHTTPError('Only admins can set cv_path', ErrorCodes.MISSING_PERMISSION)
 
             # Get the collection and experiment
@@ -753,10 +761,10 @@ class ChannelDetail(APIView):
                     return BossHTTPError('Only admins can change storage_type after creation',
                                          ErrorCodes.MISSING_PERMISSION)
 
-                if 'bucket' in data and data['bucket'] != '' and not is_admin:
+                if 'bucket' in data and data['bucket'] and not is_admin:
                     return BossHTTPError('Only admins can set bucket name', ErrorCodes.MISSING_PERMISSION)
 
-                if 'cv_path' in data and not is_admin:
+                if 'cv_path' in data and data['cv_path'] and not is_admin:
                     return BossHTTPError('Only admins can set cv_path', ErrorCodes.MISSING_PERMISSION)
 
                 # The source and related channels are names and need to be removed from the dict before serialization

--- a/django/mgmt/forms.py
+++ b/django/mgmt/forms.py
@@ -171,6 +171,9 @@ class ChannelForm(UpdateForm):
                          'sources', 'related']
     UPDATE_FIELDS = BASE_UPDATE_FIELDS.copy()
 
+    # Currently, these fields are restricted to admins.
+    ADMIN_ONLY_FIELDS = ['storage_type', 'bucket', 'cv_path']
+
     name = forms.CharField(label="Channel", help_text="String identifier unique to the experiment")
     public = forms.BooleanField(required=False, help_text="Give read access to all?")
     description = forms.CharField(required=False, help_text="Optional description")
@@ -210,7 +213,7 @@ class ChannelForm(UpdateForm):
         self.UPDATE_FIELDS = self.BASE_UPDATE_FIELDS.copy()
         is_admin = self.data.get('is_admin', False)
         if is_admin:
-            self.UPDATE_FIELDS += ['storage_type', 'bucket', 'cv_path']
+            self.UPDATE_FIELDS.extend(self.ADMIN_ONLY_FIELDS)
 
     def is_update(self):
         """
@@ -232,8 +235,8 @@ class ChannelForm(UpdateForm):
         Disable fields that only admins can access.  Use this when providing a
         create form for the non-admin user.
         """
-        self.fields['bucket'].disabled = True
-        self.fields['cv_path'].disabled = True
+        for name in self.ADMIN_ONLY_FIELDS:
+            self.fields[name].disabled = True
 
 
 def PermField():

--- a/django/mgmt/forms.py
+++ b/django/mgmt/forms.py
@@ -227,6 +227,14 @@ class ChannelForm(UpdateForm):
         self.update_fields_if_admin()
         return super().cleaned_update_data
 
+    def disable_non_admin_fields(self):
+        """
+        Disable fields that only admins can access.  Use this when providing a
+        create form for the non-admin user.
+        """
+        self.fields['bucket'].disabled = True
+        self.fields['cv_path'].disabled = True
+
 
 def PermField():
     #perms = ['read', 'add', 'update', 'delete', 'assign_group', 'remove_group']

--- a/django/mgmt/forms.py
+++ b/django/mgmt/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from bosscore.models import Channel
-from bossutils.configuration import BossConfig
+from bosscore.views.views_resource import DEFAULT_CUBOID_BUCKET_NAME
 
 class UpdateForm(forms.Form):
     '''Custom base class for forms that need to support updating
@@ -178,17 +178,15 @@ class ChannelForm(UpdateForm):
     storage_type = forms.ChoiceField(choices=(('', ''),) + Channel.STORAGE_TYPE_CHOICES,
                                      required=False,
                                      help_text='Storage backend for this channel')
-    boss_config = BossConfig()
-    try:
-        domain = '.' + boss_config['system']['fqdn'].split('.', 1)[1]
-    except Exception:
-        domain = ''
-    bucket = forms.CharField(required=False, empty_value=f'cuboids{domain}',
-                             help_text=f'(default is cuboids{domain})',
+
+    bucket = forms.CharField(required=False,
+                             empty_value=None,
+                             help_text=f'(default is {DEFAULT_CUBOID_BUCKET_NAME})',
                              label='Bucket Name')
     
     cv_path = forms.CharField(required=False, 
-                              help_text='Public S3 URI to Cloudvolume Dataset', 
+                              empty_value=None,
+                              help_text='Public S3 URI to Cloudvolume Dataset (start with / after the bucket name)',
                               label='CloudVolume Path')
 
     type = forms.ChoiceField(choices=[(c,c) for c in ['', 'image', 'annotation']],

--- a/django/mgmt/views.py
+++ b/django/mgmt/views.py
@@ -600,14 +600,20 @@ class Experiment(LoginRequiredMixin, View):
             'perms': perms,
             'exp_form': exp_form,
             'exp_error': exp_error,
-            'chan_form': chan_form if chan_form else ChannelForm(initial={"base_resolution": 0,
-                                                                          "default_time_sample": 0}),
+            'chan_form': chan_form if chan_form else None,
             'chan_error': "error" if chan_form else "",
             'meta_form': meta_form if meta_form else MetaForm(),
             'meta_error': "error" if meta_form else "",
             'perms_form': perms_form if perms_form else ResourcePermissionsForm(),
             'perms_error': "error" if perms_form else "",
         }
+        if args['chan_form'] is None:
+            is_admin = BossPermissionManager.is_in_group(request.user, ADMIN_GRP)
+            new_chan_form = ChannelForm(initial={"base_resolution": 0, "default_time_sample": 0})
+            if not is_admin:
+                new_chan_form.disable_non_admin_fields()
+            args['chan_form'] = new_chan_form
+
         return HttpResponse(render_to_string('experiment.html', args, request=request))
 
     def post(self, request, collection_name, experiment_name):


### PR DESCRIPTION
Removed default value for the bucket name from the form since only
admins allowed to specify the bucket name and we allow `null` in the DB
for backwards compatibility.

Make default value of bucket and cv_path None.  Since these fields may
be null in the DB, use None as the default value for them.

@dxenes1 I removed your change to allow blanks in the DB. I updated the form fields to provide `None` as the default value, instead.

Manual tests:
* Create channel as a non-admin
   * Try setting bucket name and cv-path
* Modify same channel as admin, setting bucket name and cv-path