### PR TITLE
Outputs specific error message when x and y voxel dimensions are not equal.

### DIFF
--- a/django/bossspatialdb/views.py
+++ b/django/bossspatialdb/views.py
@@ -404,7 +404,7 @@ class Downsample(APIView):
         voxel_size = {}
         try:                                                                                                                                                                                      
             voxel_dims = resource.get_downsampled_voxel_dims(iso=iso)                                                                                                                             
-        except Exception as e:                                                                                                                                                                    
+        except RuntimeError as e:                                                                                                                                                                    
             return BossHTTPError("Error while getting downsampled voxel dimensions: {}".format(e), ErrorCodes.BOSS_SYSTEM_ERROR)
 
         for res, dims in enumerate(voxel_dims):

--- a/django/bossspatialdb/views.py
+++ b/django/bossspatialdb/views.py
@@ -404,7 +404,7 @@ class Downsample(APIView):
         voxel_size = {}
         try:                                                                                                                                                                                      
             voxel_dims = resource.get_downsampled_voxel_dims(iso=iso)                                                                                                                             
-        except RuntimeError as e:                                                                                                                                                                    
+        except ValueError as e:                                                                                                                                                                    
             return BossHTTPError("Error while getting downsampled voxel dimensions: {}".format(e), ErrorCodes.BOSS_SYSTEM_ERROR)
 
         for res, dims in enumerate(voxel_dims):

--- a/django/bossspatialdb/views.py
+++ b/django/bossspatialdb/views.py
@@ -402,7 +402,11 @@ class Downsample(APIView):
 
         # Gen Voxel dims
         voxel_size = {}
-        voxel_dims = resource.get_downsampled_voxel_dims(iso=iso)
+        try:                                                                                                                                                                                      
+            voxel_dims = resource.get_downsampled_voxel_dims(iso=iso)                                                                                                                             
+        except Exception as e:                                                                                                                                                                    
+            return BossHTTPError("Error while getting downsampled voxel dimensions: {}".format(e), ErrorCodes.BOSS_SYSTEM_ERROR)
+
         for res, dims in enumerate(voxel_dims):
             voxel_size["{}".format(res)] = dims
 


### PR DESCRIPTION
Added exception for x and y voxel sizes being different when getting the downsampled voxel dimensions,  make sure to use the BossHTTPError class when raising errors in views.py rather than simply using the raise keyword. 