### PR TITLE
CVDB Downsample Fix

### DIFF
--- a/django/bosscore/serializers.py
+++ b/django/bosscore/serializers.py
@@ -114,7 +114,7 @@ class ChannelSerializer(serializers.ModelSerializer):
                 .format(num_time_samples)
 
         # Validate cloudvolume specific properties
-        is_cloudvol = channel_data.get('storage_type') == Channel.StorageType.CLOUD_VOLUME
+        is_cloudvol = data.get('storage_type') == Channel.StorageType.CLOUD_VOLUME
         
         # Ensure storage_type is CloudVolume if cv_path is set
         if (not is_cloudvol and data.get('cv_path') not in (None, '')):

--- a/django/bosscore/serializers.py
+++ b/django/bosscore/serializers.py
@@ -113,12 +113,18 @@ class ChannelSerializer(serializers.ModelSerializer):
             errors['default_time_sample'] = 'Ensure this value is less that the experiments num_time_samples {}.'\
                 .format(num_time_samples)
 
-        # Ensure storage_type is CloudVolume if cv_path is set.
-        if 'cv_path' in data and data['cv_path'] is not None and data['cv_path'] != '':
-            storage_type = data.get('storage_type', None)
-            if storage_type != Channel.StorageType.CLOUD_VOLUME:
-                errors['storage_type'] = f'Must be set to {Channel.StorageType.CLOUD_VOLUME}, if setting cv_path'
+        # Validate cloudvolume specific properties
+        is_cloudvol = channel_data.get('storage_type') == Channel.StorageType.CLOUD_VOLUME
+        
+        # Ensure storage_type is CloudVolume if cv_path is set
+        if (not is_cloudvol and data.get('cv_path') not in (None, '')):
+            errors['storage_type'] = f'Must be set to {Channel.StorageType.CLOUD_VOLUME}, if setting cv_path'
 
+        # Ensure channel is downsampled
+        if is_cloudvol and data.get('downsample_status') != 'DOWNSAMPLED':
+            errors['downsample_status'] = f'{Channel.StorageType.CLOUD_VOLUME} channels must be already downsampled.'
+
+        
         # Validate that base_resolution is less than the num_hierarchy_levels
         # We no longer check this because we may delete some resolutions to
         # reduce storage costs.  When we do this, we change num_hierarchy_levels

--- a/django/bosscore/views/views_resource.py
+++ b/django/bosscore/views/views_resource.py
@@ -667,7 +667,7 @@ class ChannelDetail(APIView):
                 if use_cloudvol and (cv_path is None or cv_path == ''):
                     channel_data['cv_path'] = f'/{collection}/{experiment}/{channel}'
             
-                from bossutils import bossLogger
+                from bossutils.logger import bossLogger
                 logger = bossLogger()
                 logger.info(f'DX...channel data: {channel_data}')
                 logger.info(f'DX...channel request: {request.__dict__}')

--- a/django/bosscore/views/views_resource.py
+++ b/django/bosscore/views/views_resource.py
@@ -666,6 +666,16 @@ class ChannelDetail(APIView):
                 cv_path = channel_data.get('cv_path', None)
                 if use_cloudvol and (cv_path is None or cv_path == ''):
                     channel_data['cv_path'] = f'/{collection}/{experiment}/{channel}'
+            
+                from bossutils import bossLogger
+                logger = bossLogger()
+                logger.info(f'DX...channel data: {channel_data}')
+                logger.info(f'DX...channel request: {request.__dict__}')
+                if use_cloudvol:
+                    # DX NOTE: For now we assume that cloudvolume channels are downsampled. This means
+                    # that the num_hierarchy_levels in the experiment should be limited to the available
+                    # mip levels in the cloudvolume layer.
+                    channel_data['downsample_status'] = 'DOWNSAMPLED'
 
                 # The source and related channels are names and need to be removed from the dict before serialization
                 source_channels = channel_data.pop('sources', [])

--- a/django/bosscore/views/views_resource.py
+++ b/django/bosscore/views/views_resource.py
@@ -666,11 +666,7 @@ class ChannelDetail(APIView):
                 cv_path = channel_data.get('cv_path', None)
                 if use_cloudvol and (cv_path is None or cv_path == ''):
                     channel_data['cv_path'] = f'/{collection}/{experiment}/{channel}'
-            
-                from bossutils.logger import bossLogger
-                logger = bossLogger()
-                logger.info(f'DX...channel data: {channel_data}')
-                logger.info(f'DX...channel request: {request.__dict__}')
+
                 if use_cloudvol:
                     # DX NOTE: For now we assume that cloudvolume channels are downsampled. This means
                     # that the num_hierarchy_levels in the experiment should be limited to the available

--- a/django/mgmt/templates/channel.html
+++ b/django/mgmt/templates/channel.html
@@ -36,11 +36,13 @@
                                 </div>
                                 <div class="col-xs-7">
                                     <div class="panel-body">
-                                        <a id="downsample-btn" type='button' class='btn btn-primary btn-sm action-button disabled' href='javascript:void(0);' onclick='start_downsample("{{ collection_name }}", "{{ experiment_name }}", "{{ channel_name }}")'><span class='glyphicon glyphicon-sort-by-attributes-alt' aria-hidden='true'></span> Start Downsample</a>
-                                        <a id="cancel-btn" type='button' class='btn btn-danger btn-sm action-button disabled' href='javascript:void(0);' onclick='cancel_downsample("{{collection_name }}", "{{ experiment_name }}", "{{ channel_name }}")'><span class='glyphicon glyphicon-remove' aria-hidden='true'></span> Cancel Downsample</a>
-                                        {% if user.is_staff %}
+                                        {% if channel.storage_type == "spdb" %}
+                                          <a id="downsample-btn" type='button' class='btn btn-primary btn-sm action-button disabled' href='javascript:void(0);' onclick='start_downsample("{{ collection_name }}", "{{ experiment_name }}", "{{ channel_name }}")'><span class='glyphicon glyphicon-sort-by-attributes-alt' aria-hidden='true'></span> Start Downsample</a>
+                                          <a id="cancel-btn" type='button' class='btn btn-danger btn-sm action-button disabled' href='javascript:void(0);' onclick='cancel_downsample("{{collection_name }}", "{{ experiment_name }}", "{{ channel_name }}")'><span class='glyphicon glyphicon-remove' aria-hidden='true'></span> Cancel Downsample</a>
+                                          {% if user.is_staff %}
                                             <br/><br />
                                             <a id="redownsample-btn" type='button' class='btn btn-primary btn-sm action-button' href='javascript:void(0);' onclick='start_redownsample("{{ collection_name }}", "{{ experiment_name }}", "{{ channel_name }}")'><span class='glyphicon glyphicon-sort-by-attributes-alt' aria-hidden='true'></span> Start Re-downsample</a>
+                                          {% endif %}
                                         {% endif %}
                                     </div>
                                 </div>


### PR DESCRIPTION
This PR fixes the downsample issue CVDB channels would have when displaying in neuroglancer. Specifically, CVDB channels have no way of being downsampled currently so the neuroglancer interface to BossDB would only pull down the **base resolution** of the CVDB channel. Here we make the assumption that ALL CVDB channels are already downsampled. This is a stopgap solution that can be refactored once we have a method of downsampling precompute data built-in to our service. 

This PR also removes the downsample button from the frontend console for CVDB channels.