### PR TITLE
Upgrade Markdown to 3.3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Django==2.2.18
 #django-filter==0.11.0
 djangorestframework==3.11.2
 drf-yasg==1.17.1
-Markdown==2.6.5
+Markdown==3.3.4
 mysqlclient==1.4.6
 numpy==1.18.1
 wheel==0.24.0


### PR DESCRIPTION
Fixes the metadata in browser issue. 