### PR TITLE
Update unit tests.

### DIFF
--- a/django/bosscore/test/setup_db.py
+++ b/django/bosscore/test/setup_db.py
@@ -41,6 +41,13 @@ TEST_DATA_EXPERIMENTS = [EXP1, EXP22, EXP_BASE_RES]
 
 CHAN_BASE_RES = 'chan-with-base-res'
 
+# Channel for cloudvolume tests uses this bucket name.
+CLOUD_VOL_BUCKET = 'bossdb-test-data'
+CVPATH_CHAN1 = 'col1/exp1/chan1'
+CVPATH_CHAN2 = 'col1/exp1/chan2'
+CVPATH_ANNO1 = 'col1/exp1/anno1'
+
+
 class SetupTestDB:
     def __init__(self, super_user=None):
         """
@@ -149,7 +156,7 @@ class SetupTestDB:
         self.add_collection('col2', 'Description for collection2')
 
         self.add_coordinate_frame('cf1', 'Description for cf1', 0, 1000, 0, 1000, 0, 1000, 4, 4, 4)
-        
+
         self.add_experiment('col1', 'exp1', 'cf1', 10, 10, 1)
 
         # This experiment is _purposed_ named the same as the exp in col1.
@@ -183,22 +190,22 @@ class SetupTestDB:
         self.add_experiment('col1', 'exp1', 'cf1', 10, 500, 1)
 
         # Dev Note: Prepopulated cloudvolume layer for uint8 data located at this cloudpath
-        self.add_channel('col1', 'exp1', 'chan1', 0, 0, 'uint8', 'image', 
-                storage_type='cloudvol', 
-                bucket='bossdb-test-data',
-                cv_path='col1/exp1/chan1')
-        
+        self.add_channel('col1', 'exp1', 'chan1', 0, 0, 'uint8', 'image',
+                storage_type='cloudvol',
+                bucket=CLOUD_VOL_BUCKET,
+                cv_path=CVPATH_CHAN1)
+
         # Dev Note: Prepopulated cloudvolume layer for uint16 data located at this cloudpath
-        self.add_channel('col1', 'exp1', 'chan2', 0, 0, 'uint16', 'image', 
-                storage_type='cloudvol', 
-                bucket='bossdb-test-data',
-                cv_path='col1/exp1/chan2')
-        
+        self.add_channel('col1', 'exp1', 'chan2', 0, 0, 'uint16', 'image',
+                storage_type='cloudvol',
+                bucket=CLOUD_VOL_BUCKET,
+                cv_path=CVPATH_CHAN2)
+
         # Dev Note: Prepopulated cloudvolume layer for uint16 data located at this cloudpath
-        self.add_channel('col1', 'exp1', 'anno1', 0, 0, 'uint64', 'annotation', 
-                storage_type='cloudvol', 
-                bucket='bossdb-test-data',
-                cv_path='col1/exp1/anno1')
+        self.add_channel('col1', 'exp1', 'anno1', 0, 0, 'uint64', 'annotation',
+                storage_type='cloudvol',
+                bucket=CLOUD_VOL_BUCKET,
+                cv_path=CVPATH_ANNO1)
 
     def insert_ingest_test_data(self):
 

--- a/django/bossspatialdb/test/test_djangoresource.py
+++ b/django/bossspatialdb/test/test_djangoresource.py
@@ -13,22 +13,21 @@
 # limitations under the License.
 
 from django.conf import settings
-from django.http import HttpRequest
 
 from rest_framework.test import APITestCase
-from rest_framework.request import Request
 from rest_framework.test import force_authenticate
 from rest_framework.test import APIRequestFactory
 
+from bosscore.models import Channel
 from bosscore.request import BossRequest
-from bosscore.test.setup_db import SetupTestDB
+from bosscore.test.setup_db import SetupTestDB, CLOUD_VOL_BUCKET, CVPATH_CHAN1, CVPATH_ANNO1
 from spdb.project import BossResourceDjango
 from bossspatialdb.views import Cutout
 
 version = settings.BOSS_VERSION
 
+
 class TestDjangoResourceCloudVolume(APITestCase):
-    
     def setUp(self):
         """Setup test by inserting data model items into the database"""
         self.rf = APIRequestFactory()
@@ -37,7 +36,6 @@ class TestDjangoResourceCloudVolume(APITestCase):
         dbsetup.add_role("resource-manager", self.user)
         self.client.force_login(self.user)
         dbsetup.insert_cloudvolume_test_data()
-
 
         url = '/' + version + '/cutout/col1/exp1/chan1/2/0:5/0:6/0:2/'
 
@@ -86,7 +84,6 @@ class TestDjangoResourceCloudVolume(APITestCase):
 
         self.request_annotation = BossRequest(drfrequest, request_args)
 
-    
     def test_django_resource_channel_image_cloudvol(self):
         """Test basic get channel interface
 
@@ -107,9 +104,9 @@ class TestDjangoResourceCloudVolume(APITestCase):
         assert channel.default_time_sample == self.request_channel.channel.default_time_sample
         assert channel.related == []
         assert channel.sources == []
-        assert channel.storage_type == self.request_channel.storage_type
-        assert channel.bucket == self.request_channel.bucket
-        assert channel.cv_path == self.request_channel.cv_path
+        assert channel.storage_type == Channel.StorageType.CLOUD_VOLUME
+        assert channel.bucket == CLOUD_VOL_BUCKET
+        assert channel.cv_path == CVPATH_CHAN1
 
     def test_django_resource_channel_annotation_cloudvol(self):
         """Test basic get channel when an annotation interface
@@ -130,10 +127,11 @@ class TestDjangoResourceCloudVolume(APITestCase):
         assert channel.base_resolution == self.request_annotation.channel.base_resolution
         assert channel.default_time_sample == self.request_annotation.channel.default_time_sample
         assert channel.related == []
-        assert channel.sources == ['channel1']
-        assert channel.storage_type == self.request_annotation.storage_type
-        assert channel.bucket == self.request_annotation.bucket
-        assert channel.cv_path == self.request_annotation.cv_path
+        assert channel.sources == []
+        assert channel.storage_type == Channel.StorageType.CLOUD_VOLUME
+        assert channel.bucket == CLOUD_VOL_BUCKET
+        assert channel.cv_path == CVPATH_ANNO1
+
 
 class TestDjangoResource(APITestCase):
 

--- a/django/bossspatialdb/test/test_set_downsample_arn.py
+++ b/django/bossspatialdb/test/test_set_downsample_arn.py
@@ -16,16 +16,27 @@
 This file tests a function that writes to the DB on the activity server.
 Because Django owns the DB, it makes sense for the test to live here, rather
 than in the boss-tools repo.
+
+Tests run on the endpoint server will not have the activities module, so the
+tests will be skipped if the module cannot be imported.
 """
 
-from activities.boss_db import set_downsample_arn_in_db
+try:
+    from activities.boss_db import set_downsample_arn_in_db
+    HAVE_ACTIVITIES_MODULE = True
+except Exception:
+    HAVE_ACTIVITIES_MODULE = False
+
 from bosscore.models import Channel, Collection, CoordinateFrame, Experiment
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TransactionTestCase
 import pymysql.cursors
+from unittest import skipIf
 from unittest.mock import patch
 
+
+@skipIf(not HAVE_ACTIVITIES_MODULE, 'activities module not present')
 class TestUpdateDownsampleStatus(TransactionTestCase):
     def setUp(self):
         user = User.objects.create_user(username='testuser')

--- a/django/bossspatialdb/test/test_update_downsample_status.py
+++ b/django/bossspatialdb/test/test_update_downsample_status.py
@@ -16,16 +16,27 @@
 This file tests a function that writes to the DB on the activity server.
 Because Django owns the DB, it makes sense for the test to live here, rather
 than in the boss-tools repo.
+
+Tests run on the endpoint server will not have the activities module, so the
+tests will be skipped if the module cannot be imported.
 """
 
-from activities.boss_db import update_downsample_status_in_db
+try:
+    from activities.boss_db import update_downsample_status_in_db
+    HAVE_ACTIVITIES_MODULE = True
+except Exception:
+    HAVE_ACTIVITIES_MODULE = False
+
 from bosscore.models import Channel, Collection, CoordinateFrame, Experiment
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TransactionTestCase
 import pymysql.cursors
+from unittest import skipIf
 from unittest.mock import patch
 
+
+@skipIf(not HAVE_ACTIVITIES_MODULE, 'activities module not present')
 class TestUpdateDownsampleStatus(TransactionTestCase):
     def setUp(self):
         user = User.objects.create_user(username='testuser')


### PR DESCRIPTION
Check for presence of `activities` module before running tests that
require it.  Tests run on the endpoint won't have the activities module.

Fix two broken tests related to cloudvolume support.