### PR TITLE
Complete volumetric ingests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Boss Changelog
 
+## Unreleased
+  * Improvements
+    - Volumetric ingests complete and clean up properly from the ingest client.
+
 ## 1.0.7
- * Improvements
+  * Improvements
     - Hiding Resource Delete buttons in mgmt console if the user does not have permissions to delete.
-
-
-
-

--- a/django/bossingest/ingest_manager.py
+++ b/django/bossingest/ingest_manager.py
@@ -583,8 +583,6 @@ class IngestManager:
         Returns:
             (str|None): Arn of step function if successful
         """
-        if ingest_job.ingest_type != IngestJob.TILE_INGEST:
-            return None
         args = {
             'tile_index_table': config['aws']['tile-index-table'],
             'status': 'complete',

--- a/django/bossingest/test/test_ingest_manager_complete.py
+++ b/django/bossingest/test/test_ingest_manager_complete.py
@@ -436,9 +436,3 @@ class BossIngestManagerCompleteTest(APITestCase):
         self.assertEqual(400, actual.status_code)
         self.assertEqual(ErrorCodes.BAD_REQUEST, actual.error_code)
         self.assertEqual(TILE_INDEX_QUEUE_NOT_EMPTY_ERR_MSG, actual.message)
-
-    def test_start_completion_activity_exits_if_not_tile_ingest(self):
-        job = self.make_ingest_job(status=IngestJob.UPLOADING)
-        job.ingest_type = IngestJob.VOLUMETRIC_INGEST
-
-        self.assertIsNone(self.ingest_mgr._start_completion_activity(job))


### PR DESCRIPTION
Invoke the ingest complete function for volumetric ingests. Code previously only did so for tile ingests.

### Related PR:
https://github.com/jhuapl-boss/boss-manage/pull/120