### PR TITLE
Returns 403 when revoking public

### DIFF
--- a/django/boss/urls.py
+++ b/django/boss/urls.py
@@ -53,7 +53,6 @@ urlpatterns = [
     #url(r'^docs/', include('rest_framework_swagger.urls')),
     url(r'^docs/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     url(r'^ping/', views.Ping.as_view()),
-    url(r'^token/', views.Token.as_view()),
     url(r'^metric/', views.Metric.as_view()),
 
     # deprecated urls

--- a/django/boss/views.py
+++ b/django/boss/views.py
@@ -108,6 +108,9 @@ from django.views.generic import View
 # import as to deconflict with our Token class
 from rest_framework.authtoken.models import Token as TokenModel
 
+# User name used for anonymous logins.
+PUBLIC_ACCESS_USERNAME = 'public-access'
+
 class Token(LoginRequiredMixin, View):
     def get(self, request):
         action = request.GET.get('action', None)
@@ -115,6 +118,8 @@ class Token(LoginRequiredMixin, View):
         try:
             token = TokenModel.objects.get(user = request.user)
             if action == "Revoke":
+                if request.user.username == PUBLIC_ACCESS_USERNAME:
+                    return HttpResponse(status=403, reason=f"Changing {PUBLIC_ACCESS_USERNAME}'s token forbidden")
                 token.delete()
                 token = None
         except:

--- a/django/boss/views.py
+++ b/django/boss/views.py
@@ -102,49 +102,7 @@ class Unsupported(APIView):
         return BossHTTPError(" This API version is unsupported. Update to version {}".format(version),
                              ErrorCodes.UNSUPPORTED_VERSION)
 
-from django.http import HttpResponse, HttpResponseRedirect
-from django.views.generic import View
-
-# import as to deconflict with our Token class
-from rest_framework.authtoken.models import Token as TokenModel
-
-# User name used for anonymous logins.
-PUBLIC_ACCESS_USERNAME = 'public-access'
-
-class Token(LoginRequiredMixin, View):
-    def get(self, request):
-        action = request.GET.get('action', None)
-
-        try:
-            token = TokenModel.objects.get(user = request.user)
-            if action == "Revoke":
-                if request.user.username == PUBLIC_ACCESS_USERNAME:
-                    return HttpResponse(status=403, reason=f"Changing {PUBLIC_ACCESS_USERNAME}'s token forbidden")
-                token.delete()
-                token = None
-        except:
-            if action == "Generate":
-                token = TokenModel.objects.create(user = request.user)
-            else:
-                token = None
-
-        if token is None:
-            content = ""
-            button = "Generate"
-        else:
-            content = "<textarea>{}</textarea>".format(token)
-            button = "Revoke"
-
-        html = """
-        <html>
-            <head><title>BOSS Token Management</title></head>
-            <body>
-                    {1}
-                    <a href="{0}?action={2}">{2}</a>
-            </body>
-        </html>
-        """.format(request.path_info, content, button)
-        return HttpResponse(html)
+from django.http import HttpResponse
 
 from boss.throttling import MetricDatabase
 from bosscore.constants import ADMIN_USER


### PR DESCRIPTION
This Token view is separate from the one present in the management console hidden inside the Boss API views page. It allowed users to access tokens on api.bossdb.io/token and revoke them through a GET request. 

The following PR removes the ability for tokens to be revoked if they username is public-access. If this route is not used for anything critical, I recommend we remove it entirely however. 