### PR TITLE
Modifies GET user_role endpoint

### DIFF
--- a/django/bosscore/privileges.py
+++ b/django/bosscore/privileges.py
@@ -79,11 +79,10 @@ def check_role(role_name):
     def check_role_decorator(func):
         @wraps(func)
         def wrapped(self, *args, **kwargs):
-            if check_role: # DP ???: Why is this here?
-                bpm = BossPrivilegeManager(self.request.user)
-                if not bpm.has_role(role_name) and not bpm.has_role('admin'):
-                    return BossHTTPError("{} does not have the required role {}"
-                                         .format(self.request.user, role_name), ErrorCodes.MISSING_ROLE)
+            bpm = BossPrivilegeManager(self.request.user)
+            if not bpm.has_role(role_name) and not bpm.has_role('admin'):
+                return BossHTTPError("{} does not have the required role {}"
+                                     .format(self.request.user, role_name), ErrorCodes.MISSING_ROLE)
             return func(self, *args, **kwargs)
 
         return wrapped

--- a/django/sso/tests/test_user_roles.py
+++ b/django/sso/tests/test_user_roles.py
@@ -50,7 +50,7 @@ class TestBossUserRole(TestBase):
         # Role 'test' will be filtered out by the view
         self.assertEqual(response.data, ['admin'])
 
-        call = mock.call.get_realm_roles('test')
+        call = mock.call.get_realm_roles('testuser')
         self.assertEqual(ctxMgr.mock_calls, [call])
 
     @mock.patch('sso.views.views_user.KeyCloakClient', autospec = True)
@@ -104,6 +104,16 @@ class TestBossUserRole(TestBase):
         self.assertEqual(response.status_code, 500)
 
     @mock.patch('sso.views.views_user.KeyCloakClient', autospec = True)
+    def test_get_self_role(self, mKCC):
+        ctxMgr = mKCC.return_value.__enter__.return_value
+        ctxMgr.get_realm_roles.side_effect = raise_error
+
+        request = self.makeRequest(get='/' + version + '/sso/user-role')
+        response = BossUserRole.as_view()(request, 'testuser')
+
+        self.assertEqual(response.status_code, 200)
+
+    @mock.patch('sso.views.views_user.KeyCloakClient', autospec = True)
     def test_post_role(self, mKCC):
         ctxMgr = mKCC.return_value.__enter__.return_value
 
@@ -113,7 +123,7 @@ class TestBossUserRole(TestBase):
         self.assertEqual(response.status_code, 201)
         self.assertIsNone(response.data)
 
-        call = mock.call.map_role_to_user('test', 'resource-manager')
+        call = mock.call.map_role_to_user('testuser', 'resource-manager')
         self.assertEqual(ctxMgr.mock_calls, [call])
 
     @mock.patch('sso.views.views_user.KeyCloakClient', autospec = True)
@@ -155,7 +165,7 @@ class TestBossUserRole(TestBase):
         self.assertEqual(response.status_code, 204)
         self.assertIsNone(response.data)
 
-        call = mock.call.remove_role_from_user('test', 'resource-manager')
+        call = mock.call.remove_role_from_user('testuser', 'resource-manager')
         self.assertEqual(ctxMgr.mock_calls, [call])
 
     @mock.patch('sso.views.views_user.KeyCloakClient', autospec = True)

--- a/django/sso/tests/test_user_roles.py
+++ b/django/sso/tests/test_user_roles.py
@@ -29,7 +29,7 @@ FAIL: test_post_role (sso.tests.test_user_roles.TestBossUserRole)
 from unittest import mock
 import json
 
-from .test_base import TestBase, raise_error
+from .test_base import TestBase, raise_error, TEST_USER, ADMIN_USER
 
 from sso.views.views_user import BossUserRole
 
@@ -42,7 +42,7 @@ class TestBossUserRole(TestBase):
         ctxMgr = mKCC.return_value.__enter__.return_value
         ctxMgr.get_realm_roles.return_value = [{'name': 'test'},{'name': 'admin'}]
 
-        request = self.makeRequest(get='/' + version + '/sso/user-role/testuser')
+        request = self.makeRequest(user=self.user_mgr_user, get='/' + version + '/sso/user-role/testuser')
         response = BossUserRole.as_view()(request, 'testuser')
 
         self.assertEqual(response.status_code, 200)
@@ -58,7 +58,7 @@ class TestBossUserRole(TestBase):
         ctxMgr = mKCC.return_value.__enter__.return_value
         ctxMgr.get_realm_roles.return_value = [{'name': 'test'},{'name': 'admin'}]
 
-        request = self.makeRequest(get='/' + version + '/sso/user-role/testuser/admin')
+        request = self.makeRequest(user=self.user_mgr_user, get='/' + version + '/sso/user-role/testuser/admin')
         response = BossUserRole.as_view()(request, 'testuser', 'admin')
 
         self.assertEqual(response.status_code, 200)
@@ -69,16 +69,31 @@ class TestBossUserRole(TestBase):
         self.assertEqual(ctxMgr.mock_calls, [call])
 
     @mock.patch('sso.views.views_user.KeyCloakClient', autospec = True)
-    def test_get_role_with_role1(self, mKCC):
+    def test_get_role_with_role_as_kwarg(self, mKCC):
         ctxMgr = mKCC.return_value.__enter__.return_value
         ctxMgr.get_realm_roles.return_value = [{'name': 'test'},{'name': 'admin'}]
 
-        request = self.makeRequest(get='/' + version + '/sso/user-role/testuser/admin')
+        request = self.makeRequest(user=self.user_mgr_user, get='/' + version + '/sso/user-role/testuser/admin')
         response = BossUserRole.as_view()(request, 'testuser', role_name='admin')
 
         self.assertEqual(response.status_code, 200)
 
         self.assertEqual(response.data, True)
+
+        call = mock.call.get_realm_roles('testuser')
+        self.assertEqual(ctxMgr.mock_calls, [call])
+
+    @mock.patch('sso.views.views_user.KeyCloakClient', autospec = True)
+    def test_get_role_as_admin(self, mKCC):
+        ctxMgr = mKCC.return_value.__enter__.return_value
+        ctxMgr.get_realm_roles.return_value = [{'name': 'test'}]
+
+        request = self.makeRequest(user=self.admin_user, get='/' + version + '/sso/user-role/testuser/admin')
+        response = BossUserRole.as_view()(request, 'testuser', role_name='admin')
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(response.data, False)
 
         call = mock.call.get_realm_roles('testuser')
         self.assertEqual(ctxMgr.mock_calls, [call])
@@ -98,7 +113,7 @@ class TestBossUserRole(TestBase):
         ctxMgr = mKCC.return_value.__enter__.return_value
         ctxMgr.get_realm_roles.side_effect = raise_error
 
-        request = self.makeRequest(get='/' + version + '/sso/user-role/testuser')
+        request = self.makeRequest(user=self.user_mgr_user, get='/' + version + '/sso/user-role/testuser')
         response = BossUserRole.as_view()(request, 'testuser')
 
         self.assertEqual(response.status_code, 500)
@@ -106,10 +121,9 @@ class TestBossUserRole(TestBase):
     @mock.patch('sso.views.views_user.KeyCloakClient', autospec = True)
     def test_get_self_role(self, mKCC):
         ctxMgr = mKCC.return_value.__enter__.return_value
-        ctxMgr.get_realm_roles.side_effect = raise_error
 
-        request = self.makeRequest(get='/' + version + '/sso/user-role')
-        response = BossUserRole.as_view()(request, 'testuser')
+        request = self.makeRequest(user=self.user, get='/' + version + '/sso/user-role')
+        response = BossUserRole.as_view()(request)
 
         self.assertEqual(response.status_code, 200)
 
@@ -117,7 +131,7 @@ class TestBossUserRole(TestBase):
     def test_post_role(self, mKCC):
         ctxMgr = mKCC.return_value.__enter__.return_value
 
-        request = self.makeRequest(post='/' + version + '/sso/user-role/testuser/resource-manager')
+        request = self.makeRequest(user=self.user_mgr_user, post='/' + version + '/sso/user-role/testuser/resource-manager')
         response = BossUserRole.as_view()(request, 'testuser', 'resource-manager')
 
         self.assertEqual(response.status_code, 201)
@@ -140,7 +154,7 @@ class TestBossUserRole(TestBase):
     def test_failed_post_role_bad_role(self, mKCC):
         ctxMgr = mKCC.return_value.__enter__.return_value
 
-        request = self.makeRequest(post='/' + version + '/sso/user-role/testuser/test')
+        request = self.makeRequest(user=self.user, post='/' + version + '/sso/user-role/testuser/test')
         response = BossUserRole.as_view()(request, 'testuser', 'test')
 
         self.assertEqual(response.status_code, 403)
@@ -150,7 +164,7 @@ class TestBossUserRole(TestBase):
         ctxMgr = mKCC.return_value.__enter__.return_value
         ctxMgr.map_role_to_user.side_effect = raise_error
 
-        request = self.makeRequest(post='/' + version + '/sso/user-role/testuser/resource-manager')
+        request = self.makeRequest(user=self.user_mgr_user, post='/' + version + '/sso/user-role/testuser/resource-manager')
         response = BossUserRole.as_view()(request, 'testuser', 'resource-manager')
 
         self.assertEqual(response.status_code, 500)
@@ -159,7 +173,7 @@ class TestBossUserRole(TestBase):
     def test_delete_role(self, mKCC):
         ctxMgr = mKCC.return_value.__enter__.return_value
 
-        request = self.makeRequest(delete='/' + version + '/sso/user-role/testuser/resource-manager')
+        request = self.makeRequest(user=self.user_mgr_user, delete='/' + version + '/sso/user-role/testuser/resource-manager')
         response = BossUserRole.as_view()(request, 'testuser', 'resource-manager')
 
         self.assertEqual(response.status_code, 204)
@@ -172,7 +186,7 @@ class TestBossUserRole(TestBase):
     def test_failed_delete_role_bad_role(self, mKCC):
         ctxMgr = mKCC.return_value.__enter__.return_value
 
-        request = self.makeRequest(delete='/' + version + '/sso/user-role/testuser/test')
+        request = self.makeRequest(user=self.user, delete='/' + version + '/sso/user-role/testuser/test')
         response = BossUserRole.as_view()(request, 'testuser', 'test')
 
         self.assertEqual(response.status_code, 403)
@@ -182,7 +196,7 @@ class TestBossUserRole(TestBase):
         ctxMgr = mKCC.return_value.__enter__.return_value
         ctxMgr.remove_role_from_user.side_effect = raise_error
 
-        request = self.makeRequest(delete='/' + version + '/sso/user-role/testuser/resource-manager')
-        response = BossUserRole.as_view()(request, 'testuser', 'resource-manager')
+        request = self.makeRequest(user=self.admin_user, delete='/' + version + f'/sso/user-role/foo/resource-manager')
+        response = BossUserRole.as_view()(request, 'foo', 'resource-manager')
 
         self.assertEqual(response.status_code, 500)

--- a/django/sso/tests/test_user_roles.py
+++ b/django/sso/tests/test_user_roles.py
@@ -42,8 +42,8 @@ class TestBossUserRole(TestBase):
         ctxMgr = mKCC.return_value.__enter__.return_value
         ctxMgr.get_realm_roles.return_value = [{'name': 'test'},{'name': 'admin'}]
 
-        request = self.makeRequest(get='/' + version + '/sso/user-role/test')
-        response = BossUserRole.as_view()(request, 'test')
+        request = self.makeRequest(get='/' + version + '/sso/user-role/testuser')
+        response = BossUserRole.as_view()(request, 'testuser')
 
         self.assertEqual(response.status_code, 200)
 
@@ -58,14 +58,14 @@ class TestBossUserRole(TestBase):
         ctxMgr = mKCC.return_value.__enter__.return_value
         ctxMgr.get_realm_roles.return_value = [{'name': 'test'},{'name': 'admin'}]
 
-        request = self.makeRequest(get='/' + version + '/sso/user-role/test/admin')
-        response = BossUserRole.as_view()(request, 'test', 'admin')
+        request = self.makeRequest(get='/' + version + '/sso/user-role/testuser/admin')
+        response = BossUserRole.as_view()(request, 'testuser', 'admin')
 
         self.assertEqual(response.status_code, 200)
 
         self.assertEqual(response.data, True)
 
-        call = mock.call.get_realm_roles('test')
+        call = mock.call.get_realm_roles('testuser')
         self.assertEqual(ctxMgr.mock_calls, [call])
 
     @mock.patch('sso.views.views_user.KeyCloakClient', autospec = True)
@@ -73,14 +73,14 @@ class TestBossUserRole(TestBase):
         ctxMgr = mKCC.return_value.__enter__.return_value
         ctxMgr.get_realm_roles.return_value = [{'name': 'test'},{'name': 'admin'}]
 
-        request = self.makeRequest(get='/' + version + '/sso/user-role/test/admin')
-        response = BossUserRole.as_view()(request, 'test', role_name='admin')
+        request = self.makeRequest(get='/' + version + '/sso/user-role/testuser/admin')
+        response = BossUserRole.as_view()(request, 'testuser', role_name='admin')
 
         self.assertEqual(response.status_code, 200)
 
         self.assertEqual(response.data, True)
 
-        call = mock.call.get_realm_roles('test')
+        call = mock.call.get_realm_roles('testuser')
         self.assertEqual(ctxMgr.mock_calls, [call])
 
     @mock.patch('sso.views.views_user.KeyCloakClient', autospec = True)
@@ -88,8 +88,8 @@ class TestBossUserRole(TestBase):
         ctxMgr = mKCC.return_value.__enter__.return_value
         ctxMgr.get_realm_roles.return_value = [{'name': 'test'},{'name': 'admin'}]
 
-        request = self.makeRequest(get='/' + version + '/sso/user-role/test/test')
-        response = BossUserRole.as_view()(request, 'test', 'test')
+        request = self.makeRequest(get='/' + version + '/sso/user-role/testuser/test')
+        response = BossUserRole.as_view()(request, 'testuser', 'test')
 
         self.assertEqual(response.status_code, 403)
 
@@ -98,8 +98,8 @@ class TestBossUserRole(TestBase):
         ctxMgr = mKCC.return_value.__enter__.return_value
         ctxMgr.get_realm_roles.side_effect = raise_error
 
-        request = self.makeRequest(get='/' + version + '/sso/user-role/test')
-        response = BossUserRole.as_view()(request, 'test')
+        request = self.makeRequest(get='/' + version + '/sso/user-role/testuser')
+        response = BossUserRole.as_view()(request, 'testuser')
 
         self.assertEqual(response.status_code, 500)
 
@@ -107,8 +107,8 @@ class TestBossUserRole(TestBase):
     def test_post_role(self, mKCC):
         ctxMgr = mKCC.return_value.__enter__.return_value
 
-        request = self.makeRequest(post='/' + version + '/sso/user-role/test/resource-manager')
-        response = BossUserRole.as_view()(request, 'test', 'resource-manager')
+        request = self.makeRequest(post='/' + version + '/sso/user-role/testuser/resource-manager')
+        response = BossUserRole.as_view()(request, 'testuser', 'resource-manager')
 
         self.assertEqual(response.status_code, 201)
         self.assertIsNone(response.data)
@@ -121,8 +121,8 @@ class TestBossUserRole(TestBase):
         """The admin roles is not allowed to be assigned through the API"""
         ctxMgr = mKCC.return_value.__enter__.return_value
 
-        request = self.makeRequest(post='/' + version + '/sso/user-role/test/admin')
-        response = BossUserRole.as_view()(request, 'test', 'admin')
+        request = self.makeRequest(post='/' + version + '/sso/user-role/testuser/admin')
+        response = BossUserRole.as_view()(request, 'testuser', 'admin')
 
         self.assertEqual(response.status_code, 403)
 
@@ -130,8 +130,8 @@ class TestBossUserRole(TestBase):
     def test_failed_post_role_bad_role(self, mKCC):
         ctxMgr = mKCC.return_value.__enter__.return_value
 
-        request = self.makeRequest(post='/' + version + '/sso/user-role/test/test')
-        response = BossUserRole.as_view()(request, 'test', 'test')
+        request = self.makeRequest(post='/' + version + '/sso/user-role/testuser/test')
+        response = BossUserRole.as_view()(request, 'testuser', 'test')
 
         self.assertEqual(response.status_code, 403)
 
@@ -140,8 +140,8 @@ class TestBossUserRole(TestBase):
         ctxMgr = mKCC.return_value.__enter__.return_value
         ctxMgr.map_role_to_user.side_effect = raise_error
 
-        request = self.makeRequest(post='/' + version + '/sso/user-role/test/resource-manager')
-        response = BossUserRole.as_view()(request, 'test', 'resource-manager')
+        request = self.makeRequest(post='/' + version + '/sso/user-role/testuser/resource-manager')
+        response = BossUserRole.as_view()(request, 'testuser', 'resource-manager')
 
         self.assertEqual(response.status_code, 500)
 
@@ -149,8 +149,8 @@ class TestBossUserRole(TestBase):
     def test_delete_role(self, mKCC):
         ctxMgr = mKCC.return_value.__enter__.return_value
 
-        request = self.makeRequest(delete='/' + version + '/sso/user-role/test/resource-manager')
-        response = BossUserRole.as_view()(request, 'test', 'resource-manager')
+        request = self.makeRequest(delete='/' + version + '/sso/user-role/testuser/resource-manager')
+        response = BossUserRole.as_view()(request, 'testuser', 'resource-manager')
 
         self.assertEqual(response.status_code, 204)
         self.assertIsNone(response.data)
@@ -162,8 +162,8 @@ class TestBossUserRole(TestBase):
     def test_failed_delete_role_bad_role(self, mKCC):
         ctxMgr = mKCC.return_value.__enter__.return_value
 
-        request = self.makeRequest(delete='/' + version + '/sso/user-role/test/test')
-        response = BossUserRole.as_view()(request, 'test', 'test')
+        request = self.makeRequest(delete='/' + version + '/sso/user-role/testuser/test')
+        response = BossUserRole.as_view()(request, 'testuser', 'test')
 
         self.assertEqual(response.status_code, 403)
 
@@ -172,7 +172,7 @@ class TestBossUserRole(TestBase):
         ctxMgr = mKCC.return_value.__enter__.return_value
         ctxMgr.remove_role_from_user.side_effect = raise_error
 
-        request = self.makeRequest(delete='/' + version + '/sso/user-role/test/resource-manager')
-        response = BossUserRole.as_view()(request, 'test', 'resource-manager')
+        request = self.makeRequest(delete='/' + version + '/sso/user-role/testuser/resource-manager')
+        response = BossUserRole.as_view()(request, 'testuser', 'resource-manager')
 
         self.assertEqual(response.status_code, 500)

--- a/django/sso/tests/test_users.py
+++ b/django/sso/tests/test_users.py
@@ -74,7 +74,7 @@ class TestBossUser(TestBase):
                 'last_name': 'last',
                 'email': 'email',
                 'password': 'password'}
-        request = self.makeRequest(post='/' + version + '/sso/user/test', data=data)
+        request = self.makeRequest(user=self.user_mgr_user, post='/' + version + '/sso/user/test', data=data)
         response = BossUser.as_view()(request, 'test')
 
         self.assertEqual(response.status_code, 201)
@@ -95,7 +95,7 @@ class TestBossUser(TestBase):
         ctxMgr = mKCC.return_value.__enter__.return_value
         ctxMgr.create_user.side_effect = raise_error
 
-        request = self.makeRequest(post='/' + version + '/sso/user/test', data={})
+        request = self.makeRequest(user=self.user_mgr_user, post='/' + version + '/sso/user/test', data={})
         response = BossUser.as_view()(request, 'test')
 
         self.assertEqual(response.status_code, 500)
@@ -109,7 +109,7 @@ class TestBossUser(TestBase):
                 'last_name': 'last',
                 'email': 'email',
                 'password': 'password'}
-        request = self.makeRequest(post='/' + version + '/sso/user/test', data=data)
+        request = self.makeRequest(user=self.user_mgr_user, post='/' + version + '/sso/user/test', data=data)
         response = BossUser.as_view()(request, 'test')
 
         self.assertEqual(response.status_code, 500)
@@ -129,7 +129,7 @@ class TestBossUser(TestBase):
     def test_delete_user(self, mKCC):
         ctxMgr = mKCC.return_value.__enter__.return_value
 
-        request = self.makeRequest(delete='/' + version + '/sso/user/test')
+        request = self.makeRequest(user=self.admin_user, delete='/' + version + '/sso/user/test')
         response = BossUser.as_view()(request, 'test')
 
         self.assertEqual(response.status_code, 204)
@@ -142,7 +142,7 @@ class TestBossUser(TestBase):
     def test_delete_user_bossadmin(self, mKCC):
         ctxMgr = mKCC.return_value.__enter__.return_value
 
-        request = self.makeRequest(delete='/' + version + '/sso/user/bossadmin')
+        request = self.makeRequest(user=self.admin_user, delete='/' + version + '/sso/user/bossadmin')
         response = BossUser.as_view()(request, 'bossadmin')
 
         self.assertEqual(response.status_code, 500)
@@ -152,7 +152,7 @@ class TestBossUser(TestBase):
         ctxMgr = mKCC.return_value.__enter__.return_value
         ctxMgr.delete_user.side_effect = raise_error
 
-        request = self.makeRequest(delete='/' + version + '/sso/user/test')
+        request = self.makeRequest(user=self.admin_user, delete='/' + version + '/sso/user/test')
         response = BossUser.as_view()(request, 'test')
 
         self.assertEqual(response.status_code, 500)

--- a/django/sso/urls/user-role-urls.py
+++ b/django/sso/urls/user-role-urls.py
@@ -19,7 +19,8 @@ app_name = 'sso'
 urlpatterns = [
 
     # URLS to add role
-    url(r'(?P<user_name>[\w_-]+)/(?P<role_name>[\w_-]+)?/?',views_user.BossUserRole.as_view()),
-
+    url(r'(?P<user_name>[\w_-]+)/(?P<role_name>[\w_-]+)?/?', views_user.BossUserRole.as_view()),
+    url(r'(?P<user_name>[\w_-]+)/?', views_user.BossUserRole.as_view()),
+    url(r'^', views_user.BossUserRole.as_view()),
 
 ]

--- a/django/sso/views/views_user.py
+++ b/django/sso/views/views_user.py
@@ -75,13 +75,6 @@ def check_for_user_manager(user):
     else:
         return None
 
-# def check_for_user_manager(user):
-#     bpm = BossPrivilegeManager(user)
-#     if not bpm.has_role('resource-manager'):
-#         return BossHTTPError(str(user) + " does not have the required role 'resource-manager'", ErrorCodes.MISSING_ROLE)
-#     else:
-#         return None
-
 class KeyCloakClientMixin:
     """
     Mixin for that returns a logged in KeyCloakClient if LOCAL_KEYCLOAK_TESTING

--- a/django/sso/views/views_user.py
+++ b/django/sso/views/views_user.py
@@ -70,8 +70,8 @@ def check_for_admin(user):
 
 def check_for_user_manager(user):
     bpm = BossPrivilegeManager(user)
-    if not bpm.has_role('user-manager'):
-        return BossHTTPError(str(user) + " does not have the required role 'user-manager'", ErrorCodes.MISSING_ROLE)
+    if not bpm.has_role('user-manager') and not bpm.has_role('admin'):
+        return BossHTTPError(str(user) + " does not have the required role 'user-manager' or 'admin'", ErrorCodes.MISSING_ROLE)
     else:
         return None
 

--- a/django/sso/views/views_user.py
+++ b/django/sso/views/views_user.py
@@ -68,6 +68,20 @@ def check_for_admin(user):
     else:
         return None
 
+def check_for_user_manager(user):
+    bpm = BossPrivilegeManager(user)
+    if not bpm.has_role('user-manager'):
+        return BossHTTPError(str(user) + " does not have the required role 'user-manager'", ErrorCodes.MISSING_ROLE)
+    else:
+        return None
+
+# def check_for_user_manager(user):
+#     bpm = BossPrivilegeManager(user)
+#     if not bpm.has_role('resource-manager'):
+#         return BossHTTPError(str(user) + " does not have the required role 'resource-manager'", ErrorCodes.MISSING_ROLE)
+#     else:
+#         return None
+
 class KeyCloakClientMixin:
     """
     Mixin for that returns a logged in KeyCloakClient if LOCAL_KEYCLOAK_TESTING
@@ -217,14 +231,16 @@ class BossUserRole(APIView, KeyCloakClientMixin):
     View to assign role to users
     """
 
-    @check_role("user-manager")
     @validate_role()
-    def get(self, request, user_name, role_name=None):
+    def get(self, request, user_name=None, role_name=None):
         """
         Multi-function method
-        1) If role_name is None, return all roles assigned to the user
-        2) If role_name is not None, return True/False if the user
-           is assigned the given role
+        1) if user_name and role_name is None, return all roles assigned to 
+            logged-in user
+        2) If role_name is None but username is specified return all roles 
+            assigned to the specified user
+        3) If role_name and username specfied, return True/False if the user
+            is assigned the given role
 
         Args:
            request: Django rest framework request
@@ -236,6 +252,15 @@ class BossUserRole(APIView, KeyCloakClientMixin):
         """
         try:
             with self.get_keycloak_client() as kc:
+                signed_in_user = request.GET.get('user', str(request.user))
+
+                if user_name is None:
+                    user_name = signed_in_user
+                else:
+                    resp = check_for_user_manager(signed_in_user)
+                    if resp is not None:
+                        return resp
+                
                 resp = kc.get_realm_roles(user_name)
                 roles = [r['name'] for r in resp]
                 roles = filter_roles(roles)


### PR DESCRIPTION
Nicole needed a way to get a logged-in user's roles without needing an admin account. However, the issue is that the GET user_roles endpoint requires "user-manager" role which blocks us from authorizing users to make edits to the metadata site.  

This change drop the "user-manager" requirement on the GET user_roles endpoint and allow anyone to request a list of their own roles for their account. "user-manager" role is required if you want to know the role of other usernames still. 
